### PR TITLE
Add abillity to set integration request parameters

### DIFF
--- a/syndicate/connection/api_gateway_connection.py
+++ b/syndicate/connection/api_gateway_connection.py
@@ -276,7 +276,35 @@ class ApiGatewayConnection(object):
     def create_service_integration(self, acc_id, api_id, resource_id,
                                    method, integration_method, role,
                                    action, request_templates=None,
-                                   passthrough_behavior=None):
+                                   passthrough_behavior=None,
+                                   request_parameters=None):
+        """
+        Create API Gateway integration with AWS service.
+
+        :type acc_id: str
+        :param acc_id: Account id
+        :type api_id: str
+        :param api_id: Identifier of the RestApi
+        :type resource_id: str
+        :param resource_id: Request's resource ID
+        :type method: str
+        :param method: Request's HTTP method
+        :type integration_method: str
+        :param integration_method: Integration HTTP method
+        :type role: str
+        :param role: Execution role
+        :type action: str
+        :param action: using for URI, general template:
+        {region}:{subdomain.service|service}:path|action/{service_api}
+        :type request_templates: dict
+        :param request_templates: A key-value map where content type is a key
+        and the template is the value
+        :type passthrough_behavior: str
+        :param passthrough_behavior: WHEN_NO_MATCH , WHEN_NO_TEMPLATES , NEVER
+        :type request_parameters: dict
+        :param request_parameters: A key-value map specifying request parameters
+         (path, query string, header)
+        """
         uri = 'arn:aws:apigateway:{0}'.format(action)
 
         credentials = 'arn:aws:iam::*:user/*' if role == 'caller_identity' \
@@ -291,6 +319,8 @@ class ApiGatewayConnection(object):
             params['passthrough_behavior'] = passthrough_behavior
         if request_templates:
             params['request_templates'] = request_templates
+        if request_parameters:
+            params['request_parameters'] = request_parameters
         self.create_integration(**params)
 
     def create_mock_integration(self, api_id, resource_id, method,

--- a/syndicate/core/resources/api_gateway_resource.py
+++ b/syndicate/core/resources/api_gateway_resource.py
@@ -430,6 +430,7 @@ class ApiGatewayResource(BaseResource):
         body_template = method_meta.get('integration_request_body_template')
         passthrough_behavior = method_meta.get(
             'integration_passthrough_behavior')
+        request_parameters = method_meta.get('integration_request_parameters')
         # TODO split to map - func implementation
         if integration_type:
             if integration_type == 'lambda':
@@ -472,7 +473,8 @@ class ApiGatewayResource(BaseResource):
                                                            integration_method,
                                                            role, uri,
                                                            body_template,
-                                                           passthrough_behavior)
+                                                           passthrough_behavior,
+                                                           request_parameters)
             elif integration_type == 'mock':
                 self.connection.create_mock_integration(api_id, resource_id,
                                                         method,


### PR DESCRIPTION
**Explain the *details* for making this change. What existing problem does the pull request solve?**

Implementation of #76 
Added the ability to set integration parameters to make API Gateway creation more automatic. Also added docstring in function `create_service_integration`.

**Test plan (required)**

An example of declaring integration parameters in deployment_resources.json:
```
{
   ...
         "POST": {
           "integration_request_parameters": {
             "integration.request.path.name": "method.request.path.username",
             "integration.request.querystring.username": "method.request.querystring.username",
             "integration.request.header.Content-Type": "'application/x-amz-json-1.1'"
           }
       }
    ...
}
```
So, the template for key is `integration.request.{location}.{name}` and for value is `method.request.{location}.{name}`.

The result of this snippet is shown on the screenshot below:
![изображение](https://user-images.githubusercontent.com/60649733/110500173-98984b00-8101-11eb-89b5-166882acc48f.png)

