### PR TITLE
Add request validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.9.5] - 2020-03-11
+## [0.9.5] - 2021-03-11
 ### Changed
 - Updated Python project examples
-
+- Added integration request parameters for API Gateway
+- Added request validator for API Gateway
 
 ## [0.9.4] - 2020-10-16
 ### Changed

--- a/syndicate/connection/api_gateway_connection.py
+++ b/syndicate/connection/api_gateway_connection.py
@@ -237,7 +237,6 @@ class ApiGatewayConnection(object):
             validator_name = None
 
         request_validator_params = {}
-        SETTED_PARAMETERS = 3
 
         if ('validate_request_body', True) in request_validator.items():
             request_validator_params.update({'validateRequestBody': True,
@@ -246,6 +245,12 @@ class ApiGatewayConnection(object):
             request_validator_params.update({'validateRequestParameters': True,
                                              'name': 'Validate query string '
                                                      'parameters and headers'})
+
+        # Need an additional check for validator name.
+        # If the user wants to validate both the body and the parameters,
+        # the number of 'request_validator_params' parameters will be equal
+        # to three
+        SETTED_PARAMETERS = 3
 
         if len(request_validator_params) == SETTED_PARAMETERS:
             request_validator_params.update({'name': 'Validate body, query '

--- a/syndicate/connection/api_gateway_connection.py
+++ b/syndicate/connection/api_gateway_connection.py
@@ -237,6 +237,7 @@ class ApiGatewayConnection(object):
             validator_name = None
 
         request_validator_params = {}
+        SETTED_PARAMETERS = 3
 
         if ('validate_request_body', True) in request_validator.items():
             request_validator_params.update({'validateRequestBody': True,
@@ -246,11 +247,11 @@ class ApiGatewayConnection(object):
                                              'name': 'Validate query string '
                                                      'parameters and headers'})
 
-        if not validator_name and len(request_validator_params) == 3:
-            request_validator_params.update({'name':
-                                                 'Validate body, query string '
-                                                 'parameters, and headers'})
-        elif validator_name and len(request_validator_params) < 3:
+        if len(request_validator_params) == SETTED_PARAMETERS:
+            request_validator_params.update({'name': 'Validate body, query '
+                                                     'string parameters, '
+                                                     'and headers'})
+        if validator_name:
             request_validator_params.update({'name': validator_name})
 
         request_validator_id = self.client.create_request_validator(

--- a/syndicate/connection/api_gateway_connection.py
+++ b/syndicate/connection/api_gateway_connection.py
@@ -171,7 +171,8 @@ class ApiGatewayConnection(object):
     def create_method(self, api_id, resource_id, method,
                       authorization_type=None, authorizer_id=None,
                       api_key_required=None, request_parameters=None,
-                      request_models=None):
+                      request_models=None,
+                      request_validator=None):
         """
         :type api_id: str
         :type resource_id: str
@@ -195,6 +196,10 @@ class ApiGatewayConnection(object):
         request's content type. Request models are represented as a key/value
         map, with a content type as the key and a Model name as the value.
         {'string': 'string'}
+        :type request_validator: dict
+        :param request_validator: Dictionary with values to create request
+        validator. It could contains name of validator and validate parameters
+        (validate_request_body, validate_request_parameters or both).
         """
         params = dict(restApiId=api_id, resourceId=resource_id,
                       httpMethod=method, authorizationType='NONE',
@@ -209,7 +214,49 @@ class ApiGatewayConnection(object):
             params['requestParameters'] = request_parameters
         if request_models:
             params['requestModels'] = request_models
+        if request_validator:
+            params['requestValidatorId'] = self.create_request_validator(
+                api_id, request_validator)
         self.client.put_method(**params)
+
+    def create_request_validator(self, api_id, request_validator):
+        """
+        Helper function for creating a request validator.
+
+        :type api_id: str
+        :param api_id: Identifier of the associated RestApi.
+        :type request_validator: dict
+        :param request_validator: Dictionary with values to create request
+        validator. It could contains name of validator and validate parameters
+        (validate_request_body, validate_request_parameters or both)
+        :return: str, identifier of created RequestValidator.
+        """
+        validator_name = request_validator.pop('name') if request_validator[
+            'name'] else None
+        check_params = {
+            ('validate_request_body', True): {
+                'name': 'Validate body' if not validator_name
+                else validator_name,
+                'validateRequestBody': True
+            },
+            ('validate_request_parameters', True): {
+                'name': 'Validate query string parameters and headers' if
+                not validator_name else validator_name,
+                'validateRequestParameters': True
+            }
+        }
+
+        request_validator_params = {}
+        for validation in request_validator.items():
+            request_validator_params.update(check_params[validation])
+
+        if not validator_name and len(request_validator_params) == 3:
+            request_validator_params.update(
+                name='Validate body, query string parameters, and headers')
+
+        request_validator_id = self.client.create_request_validator(
+            restApiId=api_id, **request_validator_params)['id']
+        return request_validator_id
 
     def create_integration(self, api_id, resource_id, method, int_type,
                            integration_method=None, uri=None, credentials=None,

--- a/syndicate/connection/api_gateway_connection.py
+++ b/syndicate/connection/api_gateway_connection.py
@@ -233,32 +233,25 @@ class ApiGatewayConnection(object):
         """
         try:
             validator_name = request_validator.pop('name')
-        except KeyError:  # not critical error, occurs when there is no
-            # validator name in request_validator
+        except KeyError:  # not critical error
             validator_name = None
 
-        check_params = {
-            (('validate_request_body', True),): {
-                'name': 'Validate body' if not validator_name
-                else validator_name,
-                'validateRequestBody': True
-            },
-            (('validate_request_parameters', True),): {
-                'name': 'Validate query string parameters and headers' if
-                not validator_name else validator_name,
-                'validateRequestParameters': True
-            },
-            (('validate_request_body', True),
-             ('validate_request_parameters', True)): {
-                'name': 'Validate body, query string parameters, and headers' if
-                not validator_name else validator_name,
-                'validateRequestBody': True,
-                'validateRequestParameters': True
-            }
-        }
+        request_validator_params = {}
 
-        items = request_validator.items()
-        request_validator_params = check_params[tuple(items)]
+        if ('validate_request_body', True) in request_validator.items():
+            request_validator_params.update({'validateRequestBody': True,
+                                             'name': 'Validate body'})
+        if ('validate_request_parameters', True) in request_validator.items():
+            request_validator_params.update({'validateRequestParameters': True,
+                                             'name': 'Validate query string '
+                                                     'parameters and headers'})
+
+        if not validator_name and len(request_validator_params) == 3:
+            request_validator_params.update({'name':
+                                                 'Validate body, query string '
+                                                 'parameters, and headers'})
+        elif validator_name and len(request_validator_params) < 3:
+            request_validator_params.update({'name': validator_name})
 
         request_validator_id = self.client.create_request_validator(
             restApiId=api_id, **request_validator_params)['id']

--- a/syndicate/core/build/meta_processor.py
+++ b/syndicate/core/build/meta_processor.py
@@ -232,6 +232,7 @@ def _populate_s3_path(meta, bundle_name):
 RUNTIME_PATH_RESOLVER = {
     'python2.7': _populate_s3_path_python_node,
     'python3.7': _populate_s3_path_python_node,
+    'python3.8': _populate_s3_path_python_node,
     'java8': _populate_s3_path_java,
     'nodejs10.x': _populate_s3_path_python_node,
     'nodejs8.10': _populate_s3_path_python_node

--- a/syndicate/core/resources/api_gateway_resource.py
+++ b/syndicate/core/resources/api_gateway_resource.py
@@ -423,7 +423,8 @@ class ApiGatewayResource(BaseResource):
             authorizer_id=method_meta.get('authorizer_id'),
             api_key_required=method_meta.get('api_key_required'),
             request_parameters=method_meta.get('method_request_parameters'),
-            request_models=method_meta.get('method_request_models'))
+            request_models=method_meta.get('method_request_models'),
+            request_validator=method_meta.get('request_validator'))
         # second step: create integration
         integration_type = method_meta.get('integration_type')
         # set up integration - lambda or aws service


### PR DESCRIPTION
Related to #79

**Explain the *details* for making this change. What existing problem does the pull request solve?**

Added the ability to create request validation for API Gateway via deployment_resources.json.

**Test plan (required)**
Here is the example of declaring integration parameters in deployment_resources.json:
```
...
        "request_validator": {
             "name": "${validator_name},
             "validate_request_body": true|false,
             "validate_request_parameters": true|false
           },
...
```
The name of the validator is optional. If no name is specified, it will match what Amazon sets by default (`Validate body`, `Validate query string parameters and headers` or `Validate body, query string parameters, and headers`).

The parameters `validate_request_body` and `validate_request_parameters` are false by default. 


The result of this feature is below (used custom name `Test`):
![изображение](https://user-images.githubusercontent.com/60649733/110764039-39e6e480-825b-11eb-946f-d459bf3f3884.png)

