### PR TITLE
Update Java version in Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,28 @@
+language: java
 dist: trusty
 
 addons:
+  apt:
+    packages:
+      - openjdk-8-jdk
+      - openjdk-11-jdk
   sonarcloud:
     organization: "epam"
- 
-script:
-  - cd plugin && mvn test -B
-  - cd ../examples/java/demo-java && mvn test -B
-  - cd ../../.. && sonar-scanner
+
+
+jobs:
+  include:
+    - language: java
+      dist: trusty
+      jdk: openjdk8
+
+      script:
+        - cd plugin && mvn test -B
+        - cd ../examples/java/demo-java && mvn test -B
+
+    - language: java
+      dist: trusty
+      jdk: openjdk11
+
+      script:
+        - sonar-scanner

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated Python project examples
 - Added integration request parameters for API Gateway
 - Added request validator for API Gateway
+- Update Java version in Travis builds
 
 ## [0.9.4] - 2020-10-16
 ### Changed


### PR DESCRIPTION
Related to #85 

Explain the **details** for making this change. What existing problem does the pull request solve?

All of the Travis builds fail due to the deprecated version of Java used for SonarQube Scanner.


**Test plan (required)**

SonarQube Scanner now runs on Java 11, Maven tests still runs on Java 8.

Builds run successfully:
<img width="573" alt="Screenshot 2021-03-15 at 10 15 57" src="https://user-images.githubusercontent.com/31548234/111122967-71190680-8577-11eb-87cb-ba73317e87eb.png">