### PR TITLE
#86 fix incorrect account id storing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated Python project examples
 - Added integration request parameters for API Gateway
 - Added request validator for API Gateway
+- Fixed a lost first zero issue due to incorrect work 'syndicate init' command for AWS accounts, which start at zero.
 
 ## [0.9.4] - 2020-10-16
 ### Changed

--- a/syndicate/core/handlers.py
+++ b/syndicate/core/handlers.py
@@ -78,7 +78,7 @@ def syndicate():
 @click.option('--project_path', type=str,
               help='Path to project folder. Default value: working dir')
 # account settings
-@click.option('--account_id', callback=check_required_param, type=int,
+@click.option('--account_id', callback=check_required_param, type=str,
               help='[required] Id of the AWS account where to deploy '
                    'application')
 @click.option('--region', type=str, default='us-west-1',


### PR DESCRIPTION
The account_id parameter must be of type str for correct saving in yml files

**Closing issues**

`closes #86`