### PR TITLE
add missing PATCH method to list of supported methods

### DIFF
--- a/syndicate/core/resources/api_gateway_resource.py
+++ b/syndicate/core/resources/api_gateway_resource.py
@@ -25,7 +25,8 @@ from syndicate.core.resources.helper import (build_description_obj,
 
 _LOG = get_logger('syndicate.core.resources.api_gateway_resource')
 
-SUPPORTED_METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'HEAD']
+SUPPORTED_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS',
+                     'HEAD']
 _CORS_HEADER_NAME = 'Access-Control-Allow-Origin'
 _CORS_HEADER_VALUE = "'*'"
 


### PR DESCRIPTION
Add missing PATCH method in the list of supported HTTP methods for API Gateway.

After that, aws-syndicate successfully deploys IG resources with PATCH methods.
