### PR TITLE
Attempt to load creds if they're not passed while generating config

### DIFF
--- a/syndicate/core/conf/generator.py
+++ b/syndicate/core/conf/generator.py
@@ -43,15 +43,12 @@ def generate_configuration_files(name, config_path, region,
                                  access_key, secret_key,
                                  bundle_bucket_name, prefix, suffix,
                                  project_path=None):
-    if not access_key or not secret_key:
-        _USER_LOG.warn("Access_key or secret_key weren't passed. "
-                  "Attempting to load them")
+    if not access_key and not secret_key:
+        _USER_LOG.warn("Access_key and secret_key weren't passed. "
+                       "Attempting to load them")
         credentials = Session().get_credentials()
         if not credentials:
             raise AssertionError("No credentials could be found")
-        current_credentials = credentials.get_frozen_credentials()
-        access_key = current_credentials.access_key
-        secret_key = current_credentials.secret_key
 
     try:
         sts = STSConnection(region=region,


### PR DESCRIPTION
**Attempt to load creds if they're not passed while generating config:**
If a user doesn't pass his access keys while generating config, boto3 inside the application still will try to load credentials the way it can. But even if boto3 does load them, credentials won't be saved into the generated config file. I made up some code that could resolve the problem