### PR TITLE
Fix bug suffix prefix none (urgently)

### DIFF
--- a/syndicate/core/helper.py
+++ b/syndicate/core/helper.py
@@ -402,8 +402,9 @@ def check_bundle_bucket_name(ctx, param, value):
 
 
 def check_prefix_suffix_length(ctx, param, value):
-    value = value.lower().strip()
-    result = ConfigValidator.validate_prefix_suffix(param.name, value)
-    if result:
-        raise BadParameter(result)
-    return value
+    if value:
+        value = value.lower().strip()
+        result = ConfigValidator.validate_prefix_suffix(param.name, value)
+        if result:
+            raise BadParameter(result)
+        return value


### PR DESCRIPTION
**IMPORTANT:** A fix of my previous miscoding.
If a user doesn't pass a suffix or a prefix while generating config, an exception occured. It mustn't be this way. Suffix and prefix are optional.