### PR TITLE
Api gw compression

### DIFF
--- a/syndicate/connection/api_gateway_connection.py
+++ b/syndicate/connection/api_gateway_connection.py
@@ -634,3 +634,18 @@ class ApiGatewayConnection(object):
     def get_authorizer(self, rest_api_id, authorizer_id):
         return self.client.get_authorizer(restApiId=rest_api_id,
                                           authorizerId=authorizer_id)
+
+    def update_compression_size(self, rest_api_id, compression_size=None):
+        """Enables api compression and sets minimum compression size equal
+        to given param. If the param wasn't given, will be disabled"""
+        patchOperation = {
+            'op': 'replace',
+            'path': '/minimumCompressionSize',
+        }
+        if compression_size:
+            patchOperation['value'] = str(compression_size)
+            _LOG.debug(f'Setting compression size to "{compression_size}"')
+        params = dict(restApiId=rest_api_id)
+        params['patchOperations'] = [patchOperation, ]
+        _LOG.debug(f'Updating rest api with params: "{params}"')
+        return self.client.update_rest_api(**params)

--- a/syndicate/core/resources/api_gateway_resource.py
+++ b/syndicate/core/resources/api_gateway_resource.py
@@ -188,6 +188,12 @@ class ApiGatewayResource(BaseResource):
             binary_media_types=meta.get('binary_media_types'))
         api_id = api_item['id']
 
+        # set minimumCompressionSize if the param exists
+        minimum_compression_size = meta.get('minimum_compression_size', None)
+        self.connection.update_compression_size(
+            rest_api_id=api_id,
+            compression_size=minimum_compression_size)
+
         # deploy authorizers
         authorizers = meta.get('authorizers', {})
         for key, val in authorizers.items():

--- a/syndicate/core/resources/api_gateway_resource.py
+++ b/syndicate/core/resources/api_gateway_resource.py
@@ -190,6 +190,9 @@ class ApiGatewayResource(BaseResource):
 
         # set minimumCompressionSize if the param exists
         minimum_compression_size = meta.get('minimum_compression_size', None)
+        if not minimum_compression_size:
+            _LOG.debug("No minimal_compression_size param - "
+                       "compression isn't enabled")
         self.connection.update_compression_size(
             rest_api_id=api_id,
             compression_size=minimum_compression_size)


### PR DESCRIPTION
To enable payload compression for API GW - add "minimum_compression_size" param to api_gateway resource inside deployment_resouces.json and assign the value according to API GW requirements, beginning with 0 and up till 10485760 (10M).