### PR TITLE
fix `syndicate --version` command

### DIFF
--- a/syndicate/core/handlers.py
+++ b/syndicate/core/handlers.py
@@ -62,6 +62,7 @@ from syndicate.core.project_state.status_processor import project_state_status
 from syndicate.core.project_state.sync_processor import sync_project_state
 
 INIT_COMMAND_NAME = 'init'
+SYNDICATE_PACKAGE_NAME = 'aws-syndicate'
 commands_without_config = (
     INIT_COMMAND_NAME,
     GENERATE_GROUP_NAME
@@ -73,7 +74,8 @@ def _not_require_config(all_params):
 
 
 @click.group(name='syndicate')
-@click.version_option()
+@click.version_option(package_name=SYNDICATE_PACKAGE_NAME,
+                      prog_name=SYNDICATE_PACKAGE_NAME)
 def syndicate():
     if CONF_PATH:
         click.echo('Configuration used: ' + CONF_PATH)
@@ -253,7 +255,8 @@ def update(bundle_name, deploy_name, replace_output,
     if update_only_types:
         click.echo('Types to update: {}'.format(list(update_only_types)))
     if update_only_resources:
-        click.echo('Resources to update: {}'.format(list(update_only_resources)))
+        click.echo(
+            'Resources to update: {}'.format(list(update_only_resources)))
     if update_only_resources_path:
         click.echo('Path to list of resources to update: {}'.format(
             update_only_resources_path))


### PR DESCRIPTION
Occurred due to incorrect package name provided to click (`syndicate` instead of `aws-syndicate`).
Fixed by setting optional parameters for the package name

closes #140 