### PR TITLE
Fix an issue with redundant files in nodejs assemble

### DIFF
--- a/syndicate/core/build/runtime/nodejs.py
+++ b/syndicate/core/build/runtime/nodejs.py
@@ -74,7 +74,7 @@ def _build_node_artifact(item, root, target_folder):
     req_path = Path(root, NODE_REQ_FILE_NAME)
     try:
         if os.path.exists(req_path):
-            command = 'npm install --prefix {0}'.format(root)
+            command = 'npm install'
             execute_command_by_path(command=command, path=root)
             _LOG.debug('3-rd party dependencies were installed successfully')
 


### PR DESCRIPTION
*The issue was:* if a user has nodejs lambda with dependencies in there, the first 'syndicate assemble' worked properly but left some artifacts in root lambda's folder:
![image](https://user-images.githubusercontent.com/57749020/147084433-76574048-fbf1-4aa7-bbbc-c5020a18ceaf.png)
Then during the second build 'npm install' threw us an error about some unexpected files:
![image](https://user-images.githubusercontent.com/57749020/147084521-5595ac88-242a-42fb-9635-20ec90947ba2.png)

After generating nodejs lambda its 'package.json' file contains 'name: {lambda_name}' which is also the root lambda's folder. It seems to me, due to this peculiarity 'npm install --prefix {root}' command inside nodejs build function confused a bit and installed packages wrongly. 
The commit seems to correct the issue.