### PR TITLE
Fix upload NoneType error on `syndicate upload` when there's no bundles available

### DIFF
--- a/syndicate/core/handlers.py
+++ b/syndicate/core/handlers.py
@@ -53,11 +53,10 @@ from syndicate.core.helper import (check_required_param,
                                    create_bundle_callback,
                                    handle_futures_progress_bar,
                                    resolve_path_callback, timeit,
-                                   verify_bundle_callback,
-                                   verify_meta_bundle_callback,
+                                   verify_bundle_callback, sync_lock,
                                    resolve_default_value,
                                    generate_default_bundle_name,
-                                   sync_lock)
+                                   resolve_and_verify_bundle_callback)
 from syndicate.core.project_state.project_state import (MODIFICATION_LOCK,
                                                         WARMUP_LOCK)
 from syndicate.core.project_state.status_processor import project_state_status
@@ -582,7 +581,8 @@ def create_deploy_target_bucket():
 
 
 @syndicate.command(name='upload')
-@click.option('--bundle_name', nargs=1, callback=verify_meta_bundle_callback,
+@click.option('--bundle_name', nargs=1,
+              callback=resolve_and_verify_bundle_callback,
               help='Bundle name to which the build artifacts are gathered and '
                    'later used for the deployment')
 @click.option('--force', is_flag=True, help='Flag to override existing bundle '

--- a/syndicate/core/helper.py
+++ b/syndicate/core/helper.py
@@ -256,6 +256,18 @@ def verify_meta_bundle_callback(ctx, param, value):
     return value
 
 
+def resolve_and_verify_bundle_callback(ctx, param, value):
+    if not value:
+        _LOG.debug(f'{param.name} is not specified, latest build will be used')
+        value = resolve_default_value(ctx, param, value)
+        if not value:
+            raise AssertionError(
+                'No valid bundles found for the given project. Please, '
+                'invoke \'syndicate build\' command to create a bundle.'
+            )
+    return verify_meta_bundle_callback(ctx, param, value)
+
+
 def write_content_to_file(file_path, file_name, obj):
     file_name = os.path.join(file_path, file_name)
     if os.path.exists(file_name):
@@ -291,7 +303,9 @@ def sync_lock(lock_type):
                 sys.exit(1)
             PROJECT_STATE.release_lock(lock_type)
             sync_project_state()
+
         return wrapper
+
     return real_wrapper
 
 
@@ -437,7 +451,7 @@ class ValidRegionParamType(click.types.StringParamType):
     name = 'region'
 
     def __init__(self, allowed_all=False):
-        self.allowed_all=allowed_all
+        self.allowed_all = allowed_all
 
     def convert(self, value, param, ctx):
         value = super().convert(value, param, ctx)
@@ -475,6 +489,7 @@ def check_prefix_suffix_length(ctx, param, value):
         if result:
             raise BadParameter(result)
         return value
+
 
 def resolve_project_path(ctx, param, value):
     from syndicate.core import CONFIG


### PR DESCRIPTION
Created callback that combines both resolving of latest bundle name (if not provided) and validation that bundle exists

In case of no bundles available for the project, exception with readable reason will be thrown:
<img width="1010" alt="Screenshot 2021-12-24 at 12 31 46" src="https://user-images.githubusercontent.com/31548234/147345210-b3049472-0eac-4a56-b254-f49a4546ee01.png">

closes #157
 