### PR TITLE
Fix clean issues

### DIFF
--- a/syndicate/core/handlers.py
+++ b/syndicate/core/handlers.py
@@ -240,6 +240,7 @@ def deploy(deploy_name, bundle_name, deploy_only_types, deploy_only_resources,
                    'while deploy')
 @click.option('--replace_output', nargs=1, is_flag=True, default=False)
 @check_deploy_name_for_duplicates
+@sync_lock(lock_type=MODIFICATION_LOCK)
 @timeit(action_name='update')
 def update(bundle_name, deploy_name, replace_output,
            update_only_resources,
@@ -276,7 +277,6 @@ def update(bundle_name, deploy_name, replace_output,
 
 
 @syndicate.command(name='clean')
-@timeit(action_name='clean')
 @click.option('--deploy_name', nargs=1, callback=resolve_default_value,
               help='Name of the deploy.')
 @click.option('--bundle_name', nargs=1, callback=resolve_default_value,
@@ -297,6 +297,8 @@ def update(bundle_name, deploy_name, replace_output,
               help='If specified provided types will be excluded')
 @click.option('--rollback', is_flag=True,
               help='Remove failed deploy resources')
+@sync_lock(lock_type=MODIFICATION_LOCK)
+@timeit(action_name='clean')
 def clean(deploy_name, bundle_name, clean_only_types, clean_only_resources,
           clean_only_resources_path, clean_externals, excluded_resources,
           excluded_resources_path, excluded_types, rollback):

--- a/syndicate/core/handlers.py
+++ b/syndicate/core/handlers.py
@@ -190,8 +190,6 @@ def deploy(deploy_name, bundle_name, deploy_only_types, deploy_only_resources,
     """
     Deploys the application infrastructure
     """
-    sync_project_state()
-    from syndicate.core import PROJECT_STATE
     if deploy_only_resources_path and os.path.exists(
             deploy_only_resources_path):
         deploy_resources_list = json.load(open(deploy_only_resources_path))
@@ -219,8 +217,6 @@ def deploy(deploy_name, bundle_name, deploy_only_types, deploy_only_resources,
                                                      replace_output)
     click.echo('Backend resources were deployed{0}.'.format(
         '' if deploy_success else ' with errors. See deploy output file'))
-    PROJECT_STATE.release_lock(MODIFICATION_LOCK)
-    sync_project_state()
 
 
 @syndicate.command(name='update')

--- a/syndicate/core/project_state/project_state.py
+++ b/syndicate/core/project_state/project_state.py
@@ -236,8 +236,10 @@ class ProjectState:
 
     def log_execution_event(self, **kwargs):
         operation = kwargs.get('operation')
-        if operation == 'deploy' or operation == 'update':
-            self._set_latest_deploy_info(**kwargs)
+        if operation == 'deploy':
+            params = kwargs.copy()
+            params.pop('operation')
+            self._set_latest_deploy_info(**params)
         if operation == 'clean':
             self._delete_latest_deploy_info()
 

--- a/syndicate/core/project_state/project_state.py
+++ b/syndicate/core/project_state/project_state.py
@@ -202,6 +202,19 @@ class ProjectState:
             else:
                 other_locks.update({lock_name: lock})
 
+    def actualize_latest_deploy(self, other_project_state: 'ProjectState'):
+        local_deploy = self.latest_deploy
+        remote_deploy = other_project_state.latest_deploy
+        if local_deploy and remote_deploy:
+            local_time_start = datetime.strptime(local_deploy['time_start'],
+                                                 DATE_FORMAT_ISO_8601)
+            remote_time_start = datetime.strptime(remote_deploy['time_start'],
+                                                  DATE_FORMAT_ISO_8601)
+            if remote_time_start > local_time_start:
+                self.latest_deploy = remote_deploy
+        elif remote_deploy:
+            self.latest_deploy = remote_deploy
+
     def add_lambda(self, lambda_name, runtime):
         lambdas = self._dict.get(STATE_LAMBDAS)
         if not lambdas:

--- a/syndicate/core/project_state/project_state.py
+++ b/syndicate/core/project_state/project_state.py
@@ -253,6 +253,17 @@ class ProjectState:
 
     def _delete_latest_deploy_info(self):
         self.latest_deploy = {}
+        from syndicate.core import CONN, CONFIG
+        bucket_name = CONFIG.deploy_target_bucket
+        s3 = CONN.s3()
+        remote_project_state = s3.load_file_body(bucket_name=bucket_name,
+                                                 key=PROJECT_STATE_FILE)
+        remote_project_state = yaml.unsafe_load(remote_project_state)
+        remote_project_state.latest_deploy = {}
+        s3.put_object(file_obj=yaml.dump(remote_project_state),
+                      key=PROJECT_STATE_FILE,
+                      bucket=bucket_name,
+                      content_type='application/x-yaml')
 
     def add_execution_events(self, events):
         all_events = self.events

--- a/syndicate/core/project_state/sync_processor.py
+++ b/syndicate/core/project_state/sync_processor.py
@@ -44,6 +44,7 @@ def sync_project_state():
         _LOG.debug('Actualizing the project state...')
         PROJECT_STATE.actualize_locks(remote_project_state)
         PROJECT_STATE.add_execution_events(remote_project_state.events)
+        PROJECT_STATE.actualize_latest_deploy(remote_project_state)
 
         _LOG.debug('Saving a local .syndicate file.')
         PROJECT_STATE.save()


### PR DESCRIPTION
#### Fix clean command issues. Mail pillars:
Changed the main function under 'syndicate sync' so that it also could compare and sync 'latest_deploy' property. So now if local .syndicate doesn't have 'latest_deploy' but the remote one does, the remove 'latest_deploy' will be pulled. **Important:** since the Syndicate make project state sync before and after most of actions (deploy, clean), there was a situation when: 
syndicate synced -> syndicate cleaned resources and put local latest deploy empty -> syndicate synced (hence pulled the remove latest_deploy which still existed despite cleaning). To avoid this I added erasing 'latest_deploy' from the remote .syndicate along with erasing the local one.