### PR TITLE
Simplify checking whether to assume the role or use temp creds

### DIFF
--- a/syndicate/core/__init__.py
+++ b/syndicate/core/__init__.py
@@ -175,16 +175,12 @@ def initialize_project_state():
     from syndicate.core.project_state.sync_processor import sync_project_state
     global PROJECT_STATE
     if not ProjectState.check_if_project_state_exists(CONFIG.project_path):
-        USER_LOG.warn("Config is set and generated but project state does not "
-                      "exist, seems that you've come from the previous "
-                      "version.")
-        answer = input(f'There is no .syndicate file in {CONFIG.project_path}.'
-                       f' Do you want to create it automatically? [y/n]: ')
-        if answer.lower() in CONFIRMATION_ANSWERS:
-            PROJECT_STATE = ProjectState.build_from_structure(CONFIG)
-        else:
-            raise AssertionError(f'There is no .syndicate file in '
-                                 f'{CONFIG.project_path}. Please create it.')
+        USER_LOG.warn("\n{yellow}Config is set and generated but project "
+                      "state does not exist, seems that you've come from the "
+                      "previous version. Generating project state file "
+                      "(.syndicate) from the existing structure..."
+                      "{white}".format(yellow='\033[93m', white='\033[0m'))
+        PROJECT_STATE = ProjectState.build_from_structure(CONFIG)
     else:
         PROJECT_STATE = ProjectState(project_path=CONFIG.project_path)
 

--- a/syndicate/core/__init__.py
+++ b/syndicate/core/__init__.py
@@ -57,8 +57,7 @@ PROJECT_STATE: ProjectState = None
 
 
 def _ready_to_assume():
-    return CONFIG.access_role and CONFIG.aws_access_key_id and \
-           CONFIG.aws_secret_access_key and not CONFIG.use_temp_creds
+    return CONFIG.access_role and not CONFIG.use_temp_creds
 
 
 def _ready_to_use_creds():
@@ -83,8 +82,7 @@ def _ready_to_use_provided_temp_creds():
 
 
 def _ready_to_generate_temp_creds():
-    return not CONFIG.access_role and CONFIG.use_temp_creds \
-           and CONFIG.aws_access_key_id and CONFIG.aws_secret_access_key
+    return not CONFIG.access_role and CONFIG.use_temp_creds
 
 
 def initialize_connection():
@@ -189,8 +187,6 @@ def initialize_project_state():
                                  f'{CONFIG.project_path}. Please create it.')
     else:
         PROJECT_STATE = ProjectState(project_path=CONFIG.project_path)
-    #if CONN.s3().is_bucket_exists(CONFIG.deploy_target_bucket):
-        #sync_project_state()
 
 
 def validate_temp_credentials(aws_access_key_id, aws_secret_access_key,

--- a/syndicate/core/__init__.py
+++ b/syndicate/core/__init__.py
@@ -175,11 +175,12 @@ def initialize_project_state():
     from syndicate.core.project_state.sync_processor import sync_project_state
     global PROJECT_STATE
     if not ProjectState.check_if_project_state_exists(CONFIG.project_path):
-        USER_LOG.warn("\n{yellow}Config is set and generated but project "
+        USER_LOG.warn("\033[93mConfig is set and generated but project "
                       "state does not exist, seems that you've come from the "
-                      "previous version. Generating project state file "
+                      "previous version.\033[0m")
+        USER_LOG.warn("\033[93mGenerating project state file "
                       "(.syndicate) from the existing structure..."
-                      "{white}".format(yellow='\033[93m', white='\033[0m'))
+                      "\033[0m")
         PROJECT_STATE = ProjectState.build_from_structure(CONFIG)
     else:
         PROJECT_STATE = ProjectState(project_path=CONFIG.project_path)


### PR DESCRIPTION
* If you wanted to use `AWS_PROFILE` env variable to choose a specific credentials from `.aws/credentials` you could face an issue  when the Syndicate didn't allow to assume a role of use temp credentials based on the profile in case 'syndicate.yaml' didn't have keys itself. But obviously you don't have to keep keys in `syndicate.yaml` if you consider setting `AWS_PROFILE` so I removed some checks.
* Removed prompt whether to generate .syndicate when it doesn't exist due to the discussion and difficulties in pipelines