### PR TITLE
S3 URI Compatibility Adaptation

### DIFF
--- a/syndicate/core/__init__.py
+++ b/syndicate/core/__init__.py
@@ -26,6 +26,8 @@ from syndicate.core.conf.processor import ConfigHolder
 from syndicate.core.project_state.project_state import ProjectState
 from syndicate.core.resources.processors_mapping import ProcessorFacade
 from syndicate.core.resources.resources_provider import ResourceProvider
+from syndicate.core.conf.bucket_view import URIBucketView, RegexViewDigest, \
+    NAMED_S3_URI_PATTERN, S3_PATTERN_GROUP_NAMES
 
 _LOG = get_logger('deployment.__init__')
 USER_LOG = get_user_logger()
@@ -94,7 +96,14 @@ def initialize_connection():
     global RESOURCES_PROVIDER
     global PROCESSOR_FACADE
 
+    regex_digest = RegexViewDigest()
+    regex_digest.expression = NAMED_S3_URI_PATTERN
+    regex_digest.groups = S3_PATTERN_GROUP_NAMES
+    uri_bucket_view = URIBucketView()
+    uri_bucket_view.digest = regex_digest
+
     CONFIG = ConfigHolder(CONF_PATH)
+    CONFIG.deploy_target_bucket_view = uri_bucket_view
     sts = STSConnection(CONFIG.region, CONFIG.aws_access_key_id,
                         CONFIG.aws_secret_access_key)
     try:

--- a/syndicate/core/build/bundle_processor.py
+++ b/syndicate/core/build/bundle_processor.py
@@ -16,7 +16,7 @@
 import json
 import os
 from concurrent.futures import ThreadPoolExecutor
-
+from pathlib import PurePath
 from botocore.exceptions import ClientError
 
 from syndicate.commons.log_helper import get_logger
@@ -50,26 +50,29 @@ def create_deploy_output(bundle_name, deploy_name, output, success,
     key = _build_output_key(bundle_name=bundle_name,
                             deploy_name=deploy_name,
                             is_regular_output=success)
+    key_compound = PurePath(CONFIG.deploy_target_bucket_key_compound,
+                            key).as_posix()
     if CONN.s3().is_file_exists(CONFIG.deploy_target_bucket,
-                                key) and not replace_output:
+                                key_compound) and not replace_output:
         _LOG.warn(
             'Output file for deploy {0} already exists.'.format(deploy_name))
     else:
-        CONN.s3().put_object(output_str, key,
+        CONN.s3().put_object(output_str, key_compound,
                              CONFIG.deploy_target_bucket,
                              'application/json')
         _LOG.info('Output file with name {} has been {}'.format(
             key, 'replaced' if replace_output else 'created'))
-
 
 def remove_deploy_output(bundle_name, deploy_name):
     from syndicate.core import CONFIG, CONN
     key = _build_output_key(bundle_name=bundle_name,
                             deploy_name=deploy_name,
                             is_regular_output=True)
+    key_compound = PurePath(CONFIG.deploy_target_bucket_key_compound,
+                            key).as_posix()
     if CONN.s3().is_file_exists(CONFIG.deploy_target_bucket,
-                                key):
-        CONN.s3().remove_object(CONFIG.deploy_target_bucket, key)
+                                key_compound):
+        CONN.s3().remove_object(CONFIG.deploy_target_bucket, key_compound)
     else:
         _LOG.warn(
             'Output file for deploy {0} does not exist.'.format(deploy_name))
@@ -80,9 +83,11 @@ def remove_failed_deploy_output(bundle_name, deploy_name):
     key = _build_output_key(bundle_name=bundle_name,
                             deploy_name=deploy_name,
                             is_regular_output=False)
+    key_compound = PurePath(CONFIG.deploy_target_bucket_key_compound,
+                            key).as_posix()
     if CONN.s3().is_file_exists(CONFIG.deploy_target_bucket,
-                                key):
-        CONN.s3().remove_object(CONFIG.deploy_target_bucket, key)
+                                key_compound):
+        CONN.s3().remove_object(CONFIG.deploy_target_bucket, key_compound)
     else:
         _LOG.warn(
             'Failed output file for deploy {0} does not exist.'.format(
@@ -94,10 +99,12 @@ def load_deploy_output(bundle_name, deploy_name):
     key = _build_output_key(bundle_name=bundle_name,
                             deploy_name=deploy_name,
                             is_regular_output=True)
+    key_compound = PurePath(CONFIG.deploy_target_bucket_key_compound,
+                            key).as_posix()
     if CONN.s3().is_file_exists(
-            CONFIG.deploy_target_bucket, key):
+            CONFIG.deploy_target_bucket, key_compound):
         output_file = CONN.s3().load_file_body(
-            CONFIG.deploy_target_bucket, key)
+            CONFIG.deploy_target_bucket, key_compound)
         return json.loads(output_file)
     else:
         raise AssertionError('Deploy name {0} does not exist.'
@@ -109,11 +116,13 @@ def load_failed_deploy_output(bundle_name, deploy_name):
     key = _build_output_key(bundle_name=bundle_name,
                             deploy_name=deploy_name,
                             is_regular_output=False)
+    key_compound = PurePath(CONFIG.deploy_target_bucket_key_compound,
+                            key).as_posix()
     if CONN.s3().is_file_exists(CONFIG.deploy_target_bucket,
-                                key):
+                                key_compound):
         output_file = CONN.s3().load_file_body(
             CONFIG.deploy_target_bucket,
-            key)
+            key_compound)
         return json.loads(output_file)
     else:
         raise AssertionError('Deploy name {0} does not exist.'
@@ -123,8 +132,10 @@ def load_failed_deploy_output(bundle_name, deploy_name):
 def load_meta_resources(bundle_name):
     from syndicate.core import CONFIG, CONN
     key = build_path(bundle_name, BUILD_META_FILE_NAME)
+    key_compound = PurePath(CONFIG.deploy_target_bucket_key_compound,
+                            key).as_posix()
     meta_file = CONN.s3().load_file_body(
-        CONFIG.deploy_target_bucket, key)
+        CONFIG.deploy_target_bucket, key_compound)
     return json.loads(meta_file)
 
 
@@ -132,9 +143,11 @@ def if_bundle_exist(bundle_name):
     from syndicate.core import CONFIG, CONN
     _assert_bundle_bucket_exists()
     bundle_folder = bundle_name + DEFAULT_SEP
+    key_compound = PurePath(CONFIG.deploy_target_bucket_key_compound,
+                            bundle_folder).as_posix()
     return CONN.s3().get_keys_by_prefix(
         CONFIG.deploy_target_bucket,
-        bundle_folder)
+        key_compound)
 
 
 def upload_bundle_to_s3(bundle_name, force):
@@ -249,7 +262,9 @@ def _download_package_from_s3(conn, bucket_name, key, path):
 @unpack_kwargs
 def _put_package_to_s3(path, path_to_package):
     from syndicate.core import CONN, CONFIG
-    CONN.s3().upload_single_file(path_to_package, path,
+    key_compound = PurePath(CONFIG.deploy_target_bucket_key_compound,
+                            path).as_posix()
+    CONN.s3().upload_single_file(path_to_package, key_compound,
                                  CONFIG.deploy_target_bucket)
 
 

--- a/syndicate/core/conf/bucket_view.py
+++ b/syndicate/core/conf/bucket_view.py
@@ -1,0 +1,168 @@
+import re
+from abc import ABC, abstractmethod
+from typing import Union
+from collections.abc import Iterable
+
+NAMED_S3_URI_PATTERN = r'^(?P<proto>s3:\/\/)?(?:(?P<name>[0-9a-z\-]+)' \
+                       r'(?:\/)?)(?P<key>(?<=\/)(?:[0-9a-z\-]+(?:\/)?)+)?$'
+S3_PATTERN_GROUP_NAMES = ('proto', 'name', 'key')
+
+
+class AbstractViewDigest(ABC):
+    """
+    Abstract parsing view class.
+    """
+    @abstractmethod
+    def parse(self, value: str):
+        if not isinstance(value, str):
+            raise TypeError('Value to be parsed must be of string type.')
+
+
+class RegexViewDigest(AbstractViewDigest):
+    def __init__(self):
+        self._expression = None
+        self._groups: Iterable = tuple()
+
+    def parse(self, value: str) -> dict:
+        """
+        Regex digestion of the incoming string value.
+        :return: dict | keys = self.groups
+        """
+        super(self.__class__, self).parse(value)
+        if not self.expression:
+            raise RuntimeError('No expression has been assigned.')
+        match = self.expression.match(value)
+        return match.groupdict() if match else dict()
+
+    @property
+    def expression(self):
+        return self._expression
+
+    @expression.setter
+    def expression(self, pattern: str):
+        """
+        Prepares a regex expression, based on the provided pattern.
+        The pattern is assigned, only if the expression contains
+        requires groups, if there are any.
+        """
+        try:
+            pending = re.compile(pattern)
+        except re.error as exception:
+            raise exception
+
+        if any(each for each in self.groups if each not in pending.groupindex):
+            raise KeyError(f'Pattern {pattern}, must include'
+                           f' named groups {", ".join(self.groups)}')
+        self._expression = pending
+
+    @property
+    def groups(self) -> Iterable:
+        return self._groups
+
+    @groups.setter
+    def groups(self, other: Iterable):
+        """
+        Sets up required expression groups
+        as an iterable collection of strings.
+        """
+        if not isinstance(other, Iterable) and any(
+            each for each in other if not isinstance(each,str)
+        ):
+            raise TypeError('Required groups must be an iterable'
+                            ' and contain only string elements.')
+        self._groups = other
+
+
+class AbstractBucketView(ABC):
+    """
+    Abstract bucket view.
+    """
+    class BucketViewRuntimeError(RuntimeError):
+        """
+        The runtime parent bucket view error class.
+        """
+
+    def __init__(self):
+        self._raw = None
+        self._digest = None
+
+    @property
+    @abstractmethod
+    def name(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def raw(self):
+        return self._raw
+
+    @raw.setter
+    @abstractmethod
+    def raw(self, value: str) -> None:
+        """
+        Abstract raw value setter, which provides
+        argument type verification.
+        :raises: TypeError
+        """
+        if not self.digest:
+            raise self.BucketViewRuntimeError('View digest hasn\'t been set.')
+        if not isinstance(value, str):
+            raise TypeError('Raw value must be of string type.')
+
+    @property
+    def digest(self):
+        return self._digest
+
+    @digest.setter
+    def digest(self, other: AbstractViewDigest):
+        if isinstance(other, AbstractViewDigest):
+            self._digest = other
+        else:
+            raise TypeError('View digest-parser must '
+                            'be of AbstractViewDigest type.')
+
+
+class URIBucketView(AbstractBucketView):
+
+    class InvalidS3URIException(AbstractBucketView.BucketViewRuntimeError):
+        """
+        An error class, meant to thrown once an invalid S3 URI is inputted.
+        """
+
+    def __init__(self):
+        """
+        Initializes a bucket view, with an empty parsed-value maintainer.
+        """
+        super(self.__class__, self).__init__()
+        self._parsed = None
+
+    @property
+    def raw(self) -> Union[str, None]:
+        return self._raw
+
+    @raw.setter
+    def raw(self, value: str):
+        """
+        Installs a raw url value, which alters the
+        parsed-value maintainer in runtime.
+        """
+        super(self.__class__, self.__class__).raw.fset(self, value)
+        self._raw = value
+        self._parsed = self.digest.parse(value)
+
+    @property
+    def name(self) -> Union[str, None]:
+        """
+        Returns the name of a bucket, retrieving netloc of the url.
+        """
+        value = self._parsed.get('name', '') if self._parsed else None
+        return '' if value is None else value
+
+    @property
+    def key(self) -> str:
+        """
+        Returns the key-object path compound.
+        """
+        value = self._parsed.get('key', '') if self._parsed else None
+        return '' if value is None else value
+

--- a/syndicate/core/conf/processor.py
+++ b/syndicate/core/conf/processor.py
@@ -32,6 +32,10 @@ from syndicate.core.conf.validator import \
 from syndicate.core.constants import (DEFAULT_SEP, IAM_POLICY, IAM_ROLE,
                                       S3_BUCKET_TYPE)
 
+from syndicate.core.conf.bucket_view import \
+    AbstractBucketView, AbstractViewDigest
+from typing import Union
+
 CONFIG_FILE_NAME = 'syndicate.yml'
 ALIASES_FILE_NAME = 'syndicate_aliases.yml'
 
@@ -202,6 +206,41 @@ class ConfigHolder:
     def _resolve_variable(self, variable_name):
         return self._config_dict.get(variable_name)
 
+    def _prepare_bucket_view(self) -> Union[None, AbstractBucketView]:
+        """
+        Prepares assigned bucket view instance,
+        by providing the raw config payload.
+        Under circumstances of an error, deletes the previously installed view,
+        which defaults to using the raw format.
+        :return: [None, AbstractBucketView]
+        """
+        view = self.deploy_target_bucket_view
+        raw = self._resolve_variable(DEPLOY_TARGET_BUCKET_CFG)
+        try:
+            view.raw = raw
+            _LOG.info(f'Viewing complement, {view.__class__.__name__},'
+                      ' has been found, setting up the raw data.')
+            return view
+
+        except AttributeError:
+            _LOG.warn('No viewing complement has been found.')
+        except AbstractBucketView.BucketViewRuntimeError:
+            _LOG.warn('Viewing complement set-up has failed.')
+
+        del self.deploy_target_bucket_view
+        return None
+
+    def _resolve_bucket_view_attribute(self, attribute_name: str, default=None):
+        """
+        Retrieves bucket view value respectively to a provided attribute name.
+        """
+        if not isinstance(attribute_name, str):
+            raise KeyError('Name of an attribute must be a string.')
+        view = self.deploy_target_bucket_view
+        if view and not view.raw:
+            view = self._prepare_bucket_view()
+        return getattr(view, attribute_name, default)
+
     @property
     def default_aliases(self):
         return {
@@ -240,8 +279,33 @@ class ConfigHolder:
         return self._resolve_variable(REGION_CFG)
 
     @property
-    def deploy_target_bucket(self):
-        return self._resolve_variable(DEPLOY_TARGET_BUCKET_CFG)
+    def deploy_target_bucket(self) -> str:
+        return self._resolve_bucket_view_attribute('name',
+            self._resolve_variable(DEPLOY_TARGET_BUCKET_CFG)
+        )
+
+    @property
+    def deploy_target_bucket_key_compound(self) -> str:
+        return self._resolve_bucket_view_attribute('key', '')
+
+    @property
+    def deploy_target_bucket_view(self) -> Union[AbstractBucketView, None]:
+        return getattr(self, '_deploy_target_bucket_view', None)
+
+    @deploy_target_bucket_view.setter
+    def deploy_target_bucket_view(self, view: AbstractBucketView):
+        if not isinstance(view, AbstractBucketView):
+            _LOG.error('Bucket view couldn\'t have been set, '
+                       'due to improper type.')
+        elif not isinstance(view.digest, AbstractViewDigest):
+            _LOG.error('Bucket view couldn\'t have been set,'
+                       ' due to unassigned digest-parser property.')
+        else:
+            setattr(self, '_deploy_target_bucket_view', view)
+
+    @deploy_target_bucket_view.deleter
+    def deploy_target_bucket_view(self):
+        delattr(self, '_deploy_target_bucket_view')
 
     @property
     def iam_permissions_boundary(self):

--- a/syndicate/core/decorators.py
+++ b/syndicate/core/decorators.py
@@ -14,7 +14,7 @@
     limitations under the License.
 """
 from functools import wraps
-
+from pathlib import PurePath
 import click
 
 from syndicate.commons.log_helper import get_logger
@@ -40,9 +40,11 @@ def check_deploy_name_for_duplicates(func):
         if deploy_name and bundle_name and not replace_output:
             output_file_name = f'{bundle_name}/outputs/{deploy_name}.json'
 
+            key_compound = PurePath(CONFIG.deploy_target_bucket_key_compound,
+                                    output_file_name).as_posix()
             exists = CONN.s3().is_file_exists(
                 CONFIG.deploy_target_bucket,
-                key=output_file_name)
+                key=key_compound)
             if exists:
                 _LOG.warn(f'Output file already exists with name '
                           f'{output_file_name}. If it should be replaced with '

--- a/syndicate/core/project_state/project_state.py
+++ b/syndicate/core/project_state/project_state.py
@@ -19,7 +19,7 @@ import re
 import sys
 import time
 from datetime import datetime
-from pathlib import Path
+from pathlib import Path, PurePath
 
 import yaml
 
@@ -102,9 +102,12 @@ class ProjectState:
     def get_remote() -> 'ProjectState':
         from syndicate.core import CONN, CONFIG
         bucket_name = CONFIG.deploy_target_bucket
+        key_compound = PurePath(
+            CONFIG.deploy_target_bucket_key_compound, PROJECT_STATE_FILE
+        ).as_posix()
         s3 = CONN.s3()
         remote_project_state = s3.load_file_body(bucket_name=bucket_name,
-                                                 key=PROJECT_STATE_FILE)
+                                                 key=key_compound)
         remote_project_state = yaml.unsafe_load(remote_project_state)
         _LOG.info(f'Unsafely loaded project state file from S3 bucket. The '
                   f'retrieved object has type: '
@@ -124,9 +127,11 @@ class ProjectState:
             project_state_to_save else self.dct
         from syndicate.core import CONN, CONFIG
         bucket_name = CONFIG.deploy_target_bucket
+        key_compound = PurePath(CONFIG.deploy_target_bucket_key_compound,
+                                    PROJECT_STATE_FILE).as_posix()
         s3 = CONN.s3()
         s3.put_object(file_obj=yaml.dump(dict_to_save, sort_keys=False),
-                      key=PROJECT_STATE_FILE,
+                      key=key_compound,
                       bucket=bucket_name,
                       content_type='application/x-yaml')
 

--- a/syndicate/core/project_state/sync_processor.py
+++ b/syndicate/core/project_state/sync_processor.py
@@ -13,7 +13,6 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
-
 from syndicate.commons.log_helper import get_logger, get_user_logger
 from syndicate.core.project_state.project_state import PROJECT_STATE_FILE
 from syndicate.core.project_state.project_state import ProjectState
@@ -24,10 +23,13 @@ USER_LOG = get_user_logger()
 
 def sync_project_state():
     from syndicate.core import CONFIG, CONN, PROJECT_STATE
+    from pathlib import PurePath
     bucket_name = CONFIG.deploy_target_bucket
+    key_compound = PurePath(CONFIG.deploy_target_bucket_key_compound,
+                            PROJECT_STATE_FILE).as_posix()
     s3 = CONN.s3()
     if not s3.is_file_exists(bucket_name=bucket_name,
-                             key=PROJECT_STATE_FILE):
+                             key=key_compound):
         _LOG.debug('Remote .syndicate file does not exists. Pushing...')
         PROJECT_STATE.save_to_remote()
         _LOG.debug('Push successful')

--- a/syndicate/core/resources/lambda_resource.py
+++ b/syndicate/core/resources/lambda_resource.py
@@ -15,7 +15,7 @@
 """
 import json
 import time
-
+from pathlib import PurePath
 from botocore.exceptions import ClientError
 
 from syndicate.commons.log_helper import get_logger, get_user_logger
@@ -210,6 +210,7 @@ class LambdaResource(BaseResource):
     @unpack_kwargs
     @retry
     def _create_lambda_from_meta(self, name, meta):
+        from syndicate.core import CONFIG
         _LOG.debug('Creating lambda %s', name)
         req_params = ['iam_role_name', 'runtime', 'memory', 'timeout',
                       'func_name']
@@ -217,10 +218,13 @@ class LambdaResource(BaseResource):
         validate_params(name, meta, req_params)
 
         key = meta[S3_PATH_NAME]
-        if not self.s3_conn.is_file_exists(self.deploy_target_bucket, key):
+        key_compound = PurePath(CONFIG.deploy_target_bucket_key_compound,
+                                key).as_posix()
+        if not self.s3_conn.is_file_exists(self.deploy_target_bucket,
+                                           key_compound):
             raise AssertionError(f'Error while creating lambda: {name};'
-                                 f'Deployment package {key} does not exist '
-                                 f'in {self.deploy_target_bucket} bucket')
+                f'Deployment package {key_compound} does not exist '
+                f'in {self.deploy_target_bucket} bucket')
 
         lambda_def = self.lambda_conn.get_function(name)
         if lambda_def:
@@ -266,7 +270,7 @@ class LambdaResource(BaseResource):
             memory=meta['memory'],
             timeout=meta['timeout'],
             s3_bucket=self.deploy_target_bucket,
-            s3_key=key,
+            s3_key=key_compound,
             env_vars=meta.get('env_variables'),
             vpc_sub_nets=meta.get('subnet_ids'),
             vpc_security_group=meta.get('security_group_ids'),
@@ -340,10 +344,13 @@ class LambdaResource(BaseResource):
         validate_params(name, meta, req_params)
 
         key = meta[S3_PATH_NAME]
-        if not self.s3_conn.is_file_exists(self.deploy_target_bucket, key):
+        key_compound = PurePath(CONFIG.deploy_target_bucket_key_compound,
+                                key).as_posix()
+        if not self.s3_conn.is_file_exists(self.deploy_target_bucket,
+                                           key_compound):
             raise AssertionError(
                 'Deployment package {0} does not exist '
-                'in {1} bucket'.format(key, self.deploy_target_bucket))
+                'in {1} bucket'.format(key_compound, self.deploy_target_bucket))
 
         response = self.lambda_conn.get_function(name)
         if not response:
@@ -354,7 +361,7 @@ class LambdaResource(BaseResource):
         self.lambda_conn.update_code_source(
             lambda_name=name,
             s3_bucket=self.deploy_target_bucket,
-            s3_key=key,
+            s3_key=key_compound,
             publish_version=publish_version)
 
         # temporary solution
@@ -820,13 +827,17 @@ class LambdaResource(BaseResource):
         :param context: because of usage in 'update' flow
         :return:
         """
+        from syndicate.core import CONFIG
         req_params = ['runtimes', 'deployment_package']
 
         validate_params(name, meta, req_params)
 
         key = meta[S3_PATH_NAME]
+        key_compound = PurePath(CONFIG.deploy_target_bucket_key_compound,
+                                key).as_posix()
         file_name = key.split('/')[-1]
-        self.s3_conn.download_file(self.deploy_target_bucket, key, file_name)
+        self.s3_conn.download_file(self.deploy_target_bucket, key_compound,
+                                   file_name)
         with open(file_name, 'rb') as file_data:
             file_body = file_data.read()
         import hashlib
@@ -848,7 +859,8 @@ class LambdaResource(BaseResource):
 
         args = {'layer_name': name, 'runtimes': meta['runtimes'],
                 's3_bucket': self.deploy_target_bucket,
-                's3_key': meta[S3_PATH_NAME]}
+                's3_key': PurePath(CONFIG.deploy_target_bucket_key_compound,
+                                   meta[S3_PATH_NAME]).as_posix()}
         if meta.get('description'):
             args['description'] = meta['description']
         if meta.get('license'):


### PR DESCRIPTION
The request, contains changes, which alter the following behavior.

**Deploy Target Bucket**
When one wishes to use S3 URI, they are free to manually provide the respective value to the yaml config. The backward compatibility is satisfied by wrapping the raw the config value into a concrete `AbstractBucketView` instance, having previously composed a concrete parser class of `AbstractViewDigest` type, into the view-instance, which is presigned as the `deploy_target_bucket_view` property of the  `ConfigHolder`. The latter class, apart from the `deploy_target_bucket` property, serving as a name of the bucket, also provides the compound key / object path data, by invoking the `deploy_target_bucket_key_compound` property. Currently each use-case, which had been only prescribed to the _name_ property and autonomously assigned key-path values, consequently has been altered to amend each aforementioned key.