### PR TITLE
change error to warning if int is not in allowed values for logs_expi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [1.10.1] - 2024-01-17
+- Change from `error` to `warning` integer not provided in allowed values for
+`logs_expiration` values and set default to `30`.
+
 # [1.10.0] - 2024-01-16
 - Add parameter `logs_expiration` to `syndicate_aliases.yml` and `lambda_config.json`. 
 The default value is set to "30 days". To ensure the logs never expire, set the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 # [1.10.1] - 2024-01-17
-- Change from `error` to `warning` integer not provided in allowed values for
+- Change from `error` to `warning` if integer not provided in allowed values for
 `logs_expiration` values and set default to `30`.
 
 # [1.10.0] - 2024-01-16

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='aws-syndicate',
-    version='1.10.0',
+    version='1.10.1',
     packages=find_packages(),
     include_package_data=True,
     install_requires=[

--- a/syndicate/connection/cloud_watch_connection.py
+++ b/syndicate/connection/cloud_watch_connection.py
@@ -23,7 +23,9 @@ from botocore.exceptions import ClientError
 
 from syndicate.commons.log_helper import get_logger
 from syndicate.connection.helper import apply_methods_decorator, retry
-from syndicate.core.constants import POSSIBLE_RETENTION_DAYS
+from syndicate.core.constants import (
+    POSSIBLE_RETENTION_DAYS, DEFAULT_LOGS_EXPIRATION
+)
 
 _LOG = get_logger('syndicate.connection.cloud_watch_connection')
 
@@ -77,10 +79,12 @@ class LogsConnection(object):
         if retention_in_days == 0:
             retention_in_days = POSSIBLE_RETENTION_DAYS[-1]
         if retention_in_days not in POSSIBLE_RETENTION_DAYS:
-            raise ValueError(
-                f"Possible values for \"logs_expiration\" parameter"
-                f" are: {', '.join(map(str, POSSIBLE_RETENTION_DAYS))}"
-                f" or 0 for setting to max limit")
+            _LOG.warning(
+                f"Invalid value for 'logs_expiration': {retention_in_days}. "
+                f"Possible values: {', '.join(map(str, POSSIBLE_RETENTION_DAYS))}"
+                f" or 0 for max limit. Set default {DEFAULT_LOGS_EXPIRATION}"
+            )
+            retention_in_days = DEFAULT_LOGS_EXPIRATION
 
         log_group_name = get_lambda_log_group_name(group_name)
         self.client.create_log_group(logGroupName=log_group_name)


### PR DESCRIPTION
Change from `error` to `warning` integer not provided in allowed values for `logs_expiration` values and set default to `30`.