### PR TITLE
Lambda parameter `architecture` changed to `architectures`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [1.13.1] - 2024-02-01
+- Lambda parameter `architecture` changed to `architectures`, and the value of the key changed to a list of string
+
 # [1.13.0] - 2024-01-31
 - Add support for OpenAPI v3 deploy, update and clean-up in API Gateway
 - Implement permission setting for lambda functions in OpenAPI v3 implementations

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='aws-syndicate',
-    version='1.13.0',
+    version='1.13.1',
     packages=find_packages(),
     include_package_data=True,
     install_requires=[

--- a/syndicate/connection/lambda_connection.py
+++ b/syndicate/connection/lambda_connection.py
@@ -60,7 +60,7 @@ class LambdaConnection(object):
 
     def create_lambda(self, lambda_name, func_name,
                       role, s3_bucket, s3_key, runtime='python3.10',
-                      memory=128, timeout=300, architecture=None,
+                      memory=128, timeout=300, architectures=None,
                       vpc_sub_nets=None, vpc_security_group=None,
                       env_vars=None, dl_target_arn=None, tracing_mode=None,
                       publish_version=False, layers=None,
@@ -69,7 +69,7 @@ class LambdaConnection(object):
         :type lambda_name: str
         :type func_name: str
         :param func_name: name of the entry point function
-        :param architecture: str function architecture type ['x86_64'|'arm64']
+        :param architectures: list function architecture type ['x86_64'|'arm64']
         :type role: str
         :param role: aws arn of role
         :type s3_bucket: str
@@ -113,8 +113,8 @@ class LambdaConnection(object):
             params['SnapStart'] = {
                 'ApplyOn': snap_start
             }
-        if architecture:
-            params['Architectures'] = [architecture]
+        if architectures:
+            params['Architectures'] = architectures
         return self.client.create_function(**params)
 
     def get_existing_permissions(self, lambda_arn):

--- a/syndicate/core/build/validator/lambda_validator.py
+++ b/syndicate/core/build/validator/lambda_validator.py
@@ -29,9 +29,9 @@ class LambdaValidator:
         ephemeral_storage = self._meta.get('ephemeral_storage')
         if ephemeral_storage:
             self._validate_ephemeral_storage(ephemeral_storage)
-        architecture = self._meta.get('architecture')
-        if architecture:
-            self._validate_architecture(architecture)
+        architectures = self._meta.get('architectures')
+        if architectures:
+            self._validate_architecture(architectures)
 
     def _error(self, message):
         raise AssertionError(message)
@@ -64,11 +64,12 @@ class LambdaValidator:
             self._error('Ephemeral storage size must be between '
                         '512 and 10240 MB')
 
-    def _validate_architecture(self, architecture):
-        if architecture not in LAMBDA_ARCHITECTURE_LIST:
-            self._error(f'Specified unsupported architecture: '
-                        f'"{architecture}". Currently supported '
-                        f'architectures: {LAMBDA_ARCHITECTURE_LIST}')
+    def _validate_architecture(self, architectures):
+        for architecture in architectures:
+            if architecture not in LAMBDA_ARCHITECTURE_LIST:
+                self._error(f'Specified unsupported architecture: '
+                            f'"{architecture}". Currently supported '
+                            f'architectures: {LAMBDA_ARCHITECTURE_LIST}')
 
 
 def validate_lambda(name, meta):

--- a/syndicate/core/resources/lambda_resource.py
+++ b/syndicate/core/resources/lambda_resource.py
@@ -318,7 +318,7 @@ class LambdaResource(BaseResource):
             layers=lambda_layers_arns,
             ephemeral_storage=ephemeral_storage,
             snap_start=self._resolve_snap_start(meta=meta),
-            architecture=meta.get('architecture')
+            architectures=meta.get('architectures')
         )
         _LOG.debug('Lambda created %s', name)
         # AWS sometimes returns None after function creation, needs for


### PR DESCRIPTION
Lambda parameter `architecture` changed to `architectures`, and the value of the key changed to a list of string