### PR TITLE
syndicate clean: add `--preserve_state` parameter to keep deploy outp…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [1.15.0] - 2024-02-14
+- syndicate clean: add `--preserve_state` parameter to keep deploy output json file
+
 - # [1.14.3] - 2024-02-09
 ### Added
 - added missed import into the Java lambda template

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='aws-syndicate',
-    version='1.14.1',
+    version='1.15.0',
     packages=find_packages(),
     include_package_data=True,
     install_requires=[

--- a/syndicate/core/build/deployment_processor.py
+++ b/syndicate/core/build/deployment_processor.py
@@ -421,7 +421,8 @@ def remove_deployment_resources(deploy_name, bundle_name,
                                 clean_only_types=None,
                                 excluded_resources=None,
                                 excluded_types=None,
-                                clean_externals=None):
+                                clean_externals=None,
+                                preserve_state=None):
     from syndicate.core import CONFIG
     output = new_output = load_deploy_output(bundle_name, deploy_name)
     _LOG.info('Output file was loaded successfully')
@@ -468,7 +469,8 @@ def remove_deployment_resources(deploy_name, bundle_name,
     clean_resources(resources_list)
     # remove new_output from bucket
     if output == new_output:
-        remove_deploy_output(bundle_name, deploy_name)
+        if not preserve_state:
+            remove_deploy_output(bundle_name, deploy_name)
     else:
         for key, value in new_output.items():
             output.pop(key)
@@ -541,7 +543,8 @@ def remove_failed_deploy_resources(deploy_name, bundle_name,
                                    clean_only_types=None,
                                    excluded_resources=None,
                                    excluded_types=None,
-                                   clean_externals=None):
+                                   clean_externals=None,
+                                   preserve_state=None):
     output = load_failed_deploy_output(bundle_name, deploy_name)
     _LOG.info('Failed output file was loaded successfully')
 
@@ -572,8 +575,10 @@ def remove_failed_deploy_resources(deploy_name, bundle_name,
 
     _LOG.info('Going to clean AWS resources')
     clean_resources(resources_list)
-    # remove output from bucket
-    remove_failed_deploy_output(bundle_name, deploy_name)
+
+    if not preserve_state:
+        # remove output from bucket
+        remove_failed_deploy_output(bundle_name, deploy_name)
 
 
 def _apply_dynamic_changes(resources, output):

--- a/syndicate/core/handlers.py
+++ b/syndicate/core/handlers.py
@@ -337,10 +337,12 @@ def update(bundle_name, deploy_name, replace_output,
               help='If specified provided types will be excluded')
 @click.option('--rollback', is_flag=True,
               help='Remove failed deployed resources')
+@click.option('--preserve_state', is_flag=True,
+              help='Preserve deploy output json file after resources removal')
 @timeit(action_name=CLEAN_ACTION)
 def clean(deploy_name, bundle_name, clean_only_types, clean_only_resources,
           clean_only_resources_path, clean_externals, excluded_resources,
-          excluded_resources_path, excluded_types, rollback):
+          excluded_resources_path, excluded_types, rollback, preserve_state):
     """
     Cleans the application infrastructure
     """
@@ -374,7 +376,9 @@ def clean(deploy_name, bundle_name, clean_only_types, clean_only_resources,
             clean_only_resources=clean_only_resources,
             clean_only_types=clean_only_types,
             excluded_resources=excluded_resources,
-            excluded_types=excluded_types, clean_externals=clean_externals)
+            excluded_types=excluded_types, clean_externals=clean_externals,
+            preserve_state=preserve_state
+        )
     else:
         remove_deployment_resources(deploy_name=deploy_name,
                                     bundle_name=bundle_name,
@@ -382,7 +386,8 @@ def clean(deploy_name, bundle_name, clean_only_types, clean_only_resources,
                                     clean_only_types=clean_only_types,
                                     excluded_resources=excluded_resources,
                                     excluded_types=excluded_types,
-                                    clean_externals=clean_externals)
+                                    clean_externals=clean_externals,
+                                    preserve_state=preserve_state)
     click.echo('AWS resources were removed.')
 
 


### PR DESCRIPTION
# [1.15.0] - 2024-02-14
- syndicate clean: add `--preserve_state` parameter to keep deploy output json file