### PR TITLE
Build error with empty requirements.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [1.15.18] - 2024-03-14
+- Fixed a bug when an empty requirements.txt file with a newline would cause the project to fail to build
+
 # [1.15.17] - 2024-03-14
 - Added a possibility of usage relative path to swagger_ui OpenAPI specification file
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='aws-syndicate',
-    version='1.15.17',
+    version='1.15.18',
     packages=find_packages(),
     include_package_data=True,
     install_requires=[

--- a/syndicate/core/build/runtime/python.py
+++ b/syndicate/core/build/runtime/python.py
@@ -309,7 +309,8 @@ def install_requirements_for_platform(requirements_txt: Union[str, Path],
     fp = open(requirements_txt, 'r')
     it = (
         line.split(' #')[0].strip() for line in
-        filter(lambda line: not line.strip().startswith('#'), fp)
+        filter(lambda line: not line.strip().startswith('#') and line not in (
+            '\n', '\r\n'), fp)
     )
     failed_requirements = []
     for requirement in it:

--- a/syndicate/core/build/runtime/python.py
+++ b/syndicate/core/build/runtime/python.py
@@ -45,6 +45,7 @@ _LOG = get_logger(__name__)
 USER_LOG = get_user_logger()
 
 _PY_EXT = "*.py"
+EMPTY_LINE_CHARS = ('\n', '\r\n')
 
 
 def assemble_python_lambdas(project_path, bundles_dir):
@@ -309,8 +310,8 @@ def install_requirements_for_platform(requirements_txt: Union[str, Path],
     fp = open(requirements_txt, 'r')
     it = (
         line.split(' #')[0].strip() for line in
-        filter(lambda line: not line.strip().startswith('#') and line not in (
-            '\n', '\r\n'), fp)
+        filter(lambda line: not line.strip().startswith('#')
+                            and line not in EMPTY_LINE_CHARS, fp)
     )
     failed_requirements = []
     for requirement in it:


### PR DESCRIPTION
Fixed a bug when an empty requirements.txt file with a newline would cause the project to fail to build
