### PR TITLE
Fix/partial deploy update with extended prefix mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [1.15.18] - 2024-03-15
+- Fixed skipping deploy|update|clean resources with filtering by name when prefix and/or suffix specified in syndicate configuration.
+
 # [1.15.17] - 2024-03-14
 - Added a possibility of usage relative path to swagger_ui OpenAPI specification file
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='aws-syndicate',
-    version='1.15.18',
+    version='1.15.19',
     packages=find_packages(),
     include_package_data=True,
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='aws-syndicate',
-    version='1.15.17',
+    version='1.15.18',
     packages=find_packages(),
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
Fixed skipping deploy|update|clean resources with filtering by name when prefix and/or suffix specified in syndicate configuration.