### PR TITLE
Feature/report batch item failures sqs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # [1.12.0] - 2024-06-20
 - Added support of Python 3.12
 - Added possibility to configure `FunctionResponseTypes` for lambda functions
+- Updated maven plugin version to 1.12.0 with support of `FunctionResponseTypes`
 - Fixed an issue related to ARNs resolving in case of empty resource name
 - Fixed an issue related to improper filtering of resources in case of different types of filter usage
 - Fixed an error related to SQS FIFO Queue availability regions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# [1.12.0] - 2024-06-14
+# [1.12.0] - 2024-06-20
 - Added support of Python 3.12
+- Added possibility to configure `FunctionResponseTypes` for lambda functions
 - Fixed an issue related to ARNs resolving in case of empty resource name
 - Fixed an issue related to improper filtering of resources in case of different types of filter usage
 - Fixed an error related to SQS FIFO Queue availability regions

--- a/plugin/deployment-configuration-annotations/pom.xml
+++ b/plugin/deployment-configuration-annotations/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <groupId>net.sf.aws-syndicate</groupId>
         <artifactId>deployment-configuration-processor</artifactId>
-        <version>1.11.1</version>
+        <version>1.12.0</version>
     </parent>
 
     <artifactId>deployment-configuration-annotations</artifactId>
-    <version>1.11.1</version>
+    <version>1.12.0</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/plugin/deployment-configuration-annotations/src/main/java/com/syndicate/deployment/annotations/events/FunctionResponseType.java
+++ b/plugin/deployment-configuration-annotations/src/main/java/com/syndicate/deployment/annotations/events/FunctionResponseType.java
@@ -1,16 +1,32 @@
 package com.syndicate.deployment.annotations.events;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Map;
+import java.util.Optional;
+
 public enum FunctionResponseType {
+
     REPORT_BATCH_ITEM_FAILURES("ReportBatchItemFailures");
 
-    private final String stringValue;
+    private final String jsonValue;
+    private final static Map<String, FunctionResponseType> map = Map.of(
+            "ReportBatchItemFailures",
+            REPORT_BATCH_ITEM_FAILURES
+    );
 
-    FunctionResponseType(String stringValue) {
-        this.stringValue = stringValue;
+    FunctionResponseType(String jsonValue) {
+        this.jsonValue = jsonValue;
     }
 
-    @Override
-    public String toString() {
-        return stringValue;
+    @JsonCreator
+    public static FunctionResponseType fromValue(String value) {
+        return Optional.ofNullable(map.get(value)).orElseThrow();
+    }
+
+    @JsonValue
+    public String getJsonValue() {
+        return jsonValue;
     }
 }

--- a/plugin/deployment-configuration-annotations/src/main/java/com/syndicate/deployment/annotations/events/FunctionResponseType.java
+++ b/plugin/deployment-configuration-annotations/src/main/java/com/syndicate/deployment/annotations/events/FunctionResponseType.java
@@ -1,0 +1,16 @@
+package com.syndicate.deployment.annotations.events;
+
+public enum FunctionResponseType {
+    REPORT_BATCH_ITEM_FAILURES("ReportBatchItemFailures");
+
+    private final String stringValue;
+
+    FunctionResponseType(String stringValue) {
+        this.stringValue = stringValue;
+    }
+
+    @Override
+    public String toString() {
+        return stringValue;
+    }
+}

--- a/plugin/deployment-configuration-annotations/src/main/java/com/syndicate/deployment/annotations/events/FunctionResponseType.java
+++ b/plugin/deployment-configuration-annotations/src/main/java/com/syndicate/deployment/annotations/events/FunctionResponseType.java
@@ -1,28 +1,15 @@
 package com.syndicate.deployment.annotations.events;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-
-import java.util.Map;
-import java.util.Optional;
 
 public enum FunctionResponseType {
 
     REPORT_BATCH_ITEM_FAILURES("ReportBatchItemFailures");
 
     private final String jsonValue;
-    private final static Map<String, FunctionResponseType> map = Map.of(
-            "ReportBatchItemFailures",
-            REPORT_BATCH_ITEM_FAILURES
-    );
 
     FunctionResponseType(String jsonValue) {
         this.jsonValue = jsonValue;
-    }
-
-    @JsonCreator
-    public static FunctionResponseType fromValue(String value) {
-        return Optional.ofNullable(map.get(value)).orElseThrow();
     }
 
     @JsonValue

--- a/plugin/deployment-configuration-annotations/src/main/java/com/syndicate/deployment/annotations/events/SqsTriggerEventSource.java
+++ b/plugin/deployment-configuration-annotations/src/main/java/com/syndicate/deployment/annotations/events/SqsTriggerEventSource.java
@@ -19,11 +19,7 @@ package com.syndicate.deployment.annotations.events;
 import com.syndicate.deployment.annotations.EventSource;
 import com.syndicate.deployment.model.EventSourceType;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Repeatable;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * Created by Vladyslav Tereshchenko on 8/9/2018.
@@ -38,4 +34,5 @@ public @interface SqsTriggerEventSource {
 
     int batchSize();
 
+    boolean enableBatchReportFailures() default false;
 }

--- a/plugin/deployment-configuration-annotations/src/main/java/com/syndicate/deployment/annotations/events/SqsTriggerEventSource.java
+++ b/plugin/deployment-configuration-annotations/src/main/java/com/syndicate/deployment/annotations/events/SqsTriggerEventSource.java
@@ -19,7 +19,11 @@ package com.syndicate.deployment.annotations.events;
 import com.syndicate.deployment.annotations.EventSource;
 import com.syndicate.deployment.model.EventSourceType;
 
-import java.lang.annotation.*;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * Created by Vladyslav Tereshchenko on 8/9/2018.

--- a/plugin/deployment-configuration-annotations/src/main/java/com/syndicate/deployment/annotations/events/SqsTriggerEventSource.java
+++ b/plugin/deployment-configuration-annotations/src/main/java/com/syndicate/deployment/annotations/events/SqsTriggerEventSource.java
@@ -34,5 +34,5 @@ public @interface SqsTriggerEventSource {
 
     int batchSize();
 
-    boolean enableBatchReportFailures() default false;
+    FunctionResponseType[] functionResponseTypes() default {};
 }

--- a/plugin/deployment-configuration-annotations/src/main/java/com/syndicate/deployment/model/EventSourceType.java
+++ b/plugin/deployment-configuration-annotations/src/main/java/com/syndicate/deployment/model/EventSourceType.java
@@ -122,7 +122,9 @@ public enum EventSourceType {
             SqsTriggerEventSource sqsEventSource = (SqsTriggerEventSource) eventSource;
             return new SqsTriggerEventSourceItem.Builder()
                     .withTargetQueue(sqsEventSource.targetQueue())
-                    .withBatchSize(sqsEventSource.batchSize()).build();
+                    .withBatchSize(sqsEventSource.batchSize())
+                    .withEnableBatchReportFailures(sqsEventSource.enableBatchReportFailures())
+                    .build();
         }
 
         @Override

--- a/plugin/deployment-configuration-annotations/src/main/java/com/syndicate/deployment/model/EventSourceType.java
+++ b/plugin/deployment-configuration-annotations/src/main/java/com/syndicate/deployment/model/EventSourceType.java
@@ -123,7 +123,7 @@ public enum EventSourceType {
             return new SqsTriggerEventSourceItem.Builder()
                     .withTargetQueue(sqsEventSource.targetQueue())
                     .withBatchSize(sqsEventSource.batchSize())
-                    .withEnableBatchReportFailures(sqsEventSource.enableBatchReportFailures())
+                    .withFunctionResponseTypes(sqsEventSource.functionResponseTypes())
                     .build();
         }
 

--- a/plugin/deployment-configuration-annotations/src/main/java/com/syndicate/deployment/model/events/SqsTriggerEventSourceItem.java
+++ b/plugin/deployment-configuration-annotations/src/main/java/com/syndicate/deployment/model/events/SqsTriggerEventSourceItem.java
@@ -17,8 +17,10 @@
 package com.syndicate.deployment.model.events;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.syndicate.deployment.annotations.events.FunctionResponseType;
 import com.syndicate.deployment.model.EventSourceType;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -32,8 +34,8 @@ public class SqsTriggerEventSourceItem extends EventSourceItem {
     @JsonProperty("batch_size")
     private int batchSize;
 
-    @JsonProperty("enable_batch_report_failures")
-    private boolean enableBatchReportFailures;
+    @JsonProperty("function_response_types")
+    private FunctionResponseType[] functionResponseTypes;
 
     private SqsTriggerEventSourceItem() {
     }
@@ -46,8 +48,8 @@ public class SqsTriggerEventSourceItem extends EventSourceItem {
         return batchSize;
     }
 
-    public boolean isEnableBatchReportFailures() {
-        return enableBatchReportFailures;
+    public FunctionResponseType[] getFunctionResponseTypes() {
+        return functionResponseTypes;
     }
 
     public static class Builder {
@@ -71,8 +73,8 @@ public class SqsTriggerEventSourceItem extends EventSourceItem {
             return triggerEventSourceItem;
         }
 
-        public Builder withEnableBatchReportFailures(boolean enableBatchReportFailures) {
-            this.triggerEventSourceItem.enableBatchReportFailures = enableBatchReportFailures;
+        public Builder withFunctionResponseTypes(FunctionResponseType[] functionResponseTypes) {
+            this.triggerEventSourceItem.functionResponseTypes = functionResponseTypes;
             return this;
         }
     }
@@ -84,7 +86,7 @@ public class SqsTriggerEventSourceItem extends EventSourceItem {
 
         SqsTriggerEventSourceItem that = (SqsTriggerEventSourceItem) o;
 
-        return batchSize == that.batchSize && eventSourceType == that.eventSourceType && targetQueue.equals(that.targetQueue) && enableBatchReportFailures == that.enableBatchReportFailures;
+        return batchSize == that.batchSize && eventSourceType == that.eventSourceType && targetQueue.equals(that.targetQueue) && functionResponseTypes == that.functionResponseTypes;
 
     }
 
@@ -93,7 +95,7 @@ public class SqsTriggerEventSourceItem extends EventSourceItem {
         int result = targetQueue.hashCode();
         result = 31 * result + eventSourceType.hashCode();
         result = 31 * result + batchSize;
-        result = 31 * result + Boolean.hashCode(enableBatchReportFailures);
+        result = 31 * result + Arrays.hashCode(functionResponseTypes);
         return result;
     }
 
@@ -102,7 +104,7 @@ public class SqsTriggerEventSourceItem extends EventSourceItem {
         return "SqsTriggerEventSourceItem{" +
                 "targetQueue='" + targetQueue + '\'' +
                 ", batchSize=" + batchSize +
-                "} " + super.toString();
+                ", functionResponseTypes=" + Arrays.toString(functionResponseTypes) +
+                '}';
     }
-
 }

--- a/plugin/deployment-configuration-annotations/src/main/java/com/syndicate/deployment/model/events/SqsTriggerEventSourceItem.java
+++ b/plugin/deployment-configuration-annotations/src/main/java/com/syndicate/deployment/model/events/SqsTriggerEventSourceItem.java
@@ -32,6 +32,9 @@ public class SqsTriggerEventSourceItem extends EventSourceItem {
     @JsonProperty("batch_size")
     private int batchSize;
 
+    @JsonProperty("enable_batch_report_failures")
+    private boolean enableBatchReportFailures;
+
     private SqsTriggerEventSourceItem() {
     }
 
@@ -41,6 +44,10 @@ public class SqsTriggerEventSourceItem extends EventSourceItem {
 
     public int getBatchSize() {
         return batchSize;
+    }
+
+    public boolean isEnableBatchReportFailures() {
+        return enableBatchReportFailures;
     }
 
     public static class Builder {
@@ -63,6 +70,11 @@ public class SqsTriggerEventSourceItem extends EventSourceItem {
             triggerEventSourceItem.eventSourceType = EventSourceType.SQS_TRIGGER;
             return triggerEventSourceItem;
         }
+
+        public Builder withEnableBatchReportFailures(boolean enableBatchReportFailures) {
+            this.triggerEventSourceItem.enableBatchReportFailures = enableBatchReportFailures;
+            return this;
+        }
     }
 
     @Override
@@ -72,7 +84,7 @@ public class SqsTriggerEventSourceItem extends EventSourceItem {
 
         SqsTriggerEventSourceItem that = (SqsTriggerEventSourceItem) o;
 
-        return batchSize == that.batchSize && eventSourceType == that.eventSourceType && targetQueue.equals(that.targetQueue);
+        return batchSize == that.batchSize && eventSourceType == that.eventSourceType && targetQueue.equals(that.targetQueue) && enableBatchReportFailures == that.enableBatchReportFailures;
 
     }
 
@@ -81,6 +93,7 @@ public class SqsTriggerEventSourceItem extends EventSourceItem {
         int result = targetQueue.hashCode();
         result = 31 * result + eventSourceType.hashCode();
         result = 31 * result + batchSize;
+        result = 31 * result + Boolean.hashCode(enableBatchReportFailures);
         return result;
     }
 

--- a/plugin/deployment-configuration-maven-plugin/pom.xml
+++ b/plugin/deployment-configuration-maven-plugin/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <groupId>net.sf.aws-syndicate</groupId>
         <artifactId>deployment-configuration-processor</artifactId>
-        <version>1.11.1</version>
+        <version>1.12.0</version>
     </parent>
 
     <artifactId>deployment-configuration-maven-plugin</artifactId>
-    <version>1.11.1</version>
+    <version>1.12.0</version>
     <packaging>maven-plugin</packaging>
 
     <properties>
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>net.sf.aws-syndicate</groupId>
             <artifactId>deployment-configuration-annotations</artifactId>
-            <version>1.11.1</version>
+            <version>1.12.0</version>
         </dependency>
         <dependency>
             <groupId>org.reflections</groupId>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.sf.aws-syndicate</groupId>
     <artifactId>deployment-configuration-processor</artifactId>
-    <version>1.11.1</version>
+    <version>1.12.0</version>
     <packaging>pom</packaging>
 
     <name>aws-syndicate</name>

--- a/syndicate/connection/lambda_connection.py
+++ b/syndicate/connection/lambda_connection.py
@@ -289,7 +289,7 @@ class LambdaConnection(object):
                          batch_window: Optional[int] = None,
                          start_position=None,
                          filters: Optional[List] = None,
-                         function_response_types=None):
+                         function_response_types: Optional[List] = None):
         """ Create event source for Lambda
         :type func_name: str
         :type stream_arn: str
@@ -297,7 +297,8 @@ class LambdaConnection(object):
         :param batch_size: max limit of Lambda event process in one time
         :param start_position: option for Lambda reading event mode
         :param filters: Optional[list]
-        :param function_response_types: Optional[list] list of function response types
+        :param function_response_types: Optional[list] list of function
+               response types
         :return: response
         """
         params = dict(
@@ -502,7 +503,7 @@ class LambdaConnection(object):
 
     def update_event_source(self, uuid, function_name, batch_size,
                             batch_window=None, filters: Optional[List] = None,
-                            function_response_types=None):
+                            function_response_types: Optional[List] = None):
         params = dict(
             UUID=uuid, FunctionName=function_name, BatchSize=batch_size
         )

--- a/syndicate/connection/lambda_connection.py
+++ b/syndicate/connection/lambda_connection.py
@@ -288,7 +288,8 @@ class LambdaConnection(object):
     def add_event_source(self, func_name, stream_arn, batch_size=10,
                          batch_window: Optional[int] = None,
                          start_position=None,
-                         filters: Optional[List] = None):
+                         filters: Optional[List] = None,
+                         enable_batch_report_failures=None):
         """ Create event source for Lambda
         :type func_name: str
         :type stream_arn: str
@@ -296,6 +297,7 @@ class LambdaConnection(object):
         :param batch_size: max limit of Lambda event process in one time
         :param start_position: option for Lambda reading event mode
         :param filters: Optional[list]
+        :param enable_batch_report_failures: Optional[bool] enables batch item failures
         :return: response
         """
         params = dict(
@@ -308,7 +310,8 @@ class LambdaConnection(object):
             params['StartingPosition'] = start_position
         if filters:
             params['FilterCriteria'] = {'Filters': filters}
-
+        if enable_batch_report_failures is not None and enable_batch_report_failures:
+            params['FunctionResponseTypes'] = ['ReportBatchItemFailures']
         response = self.client.create_event_source_mapping(**params)
         return response
 
@@ -498,7 +501,8 @@ class LambdaConnection(object):
                                          Publish=publish_version)
 
     def update_event_source(self, uuid, function_name, batch_size,
-                            batch_window=None, filters: Optional[List] = None):
+                            batch_window=None, filters: Optional[List] = None,
+                            enable_batch_report_failures=None):
         params = dict(
             UUID=uuid, FunctionName=function_name, BatchSize=batch_size
         )
@@ -506,6 +510,10 @@ class LambdaConnection(object):
             params['MaximumBatchingWindowInSeconds'] = batch_window
         if filters is not None:
             params['FilterCriteria'] = {'Filters': filters}
+        if enable_batch_report_failures is not None and enable_batch_report_failures:
+            params['FunctionResponseTypes'] = ['ReportBatchItemFailures']
+        else:
+            params['FunctionResponseTypes'] = []
         return self.client.update_event_source_mapping(**params)
 
     def get_function(self, lambda_name, qualifier=None):
@@ -584,7 +592,7 @@ class LambdaConnection(object):
                                     env_vars=None, runtime=None,
                                     dead_letter_arn=None, kms_key_arn=None,
                                     layers=None, ephemeral_storage=None,
-                                    snap_start: str =None):
+                                    snap_start: str = None):
         params = dict(FunctionName=lambda_name)
         if ephemeral_storage:
             params['EphemeralStorage'] = {'Size': ephemeral_storage}

--- a/syndicate/connection/lambda_connection.py
+++ b/syndicate/connection/lambda_connection.py
@@ -289,7 +289,7 @@ class LambdaConnection(object):
                          batch_window: Optional[int] = None,
                          start_position=None,
                          filters: Optional[List] = None,
-                         enable_batch_report_failures=None):
+                         function_response_types=None):
         """ Create event source for Lambda
         :type func_name: str
         :type stream_arn: str
@@ -297,7 +297,7 @@ class LambdaConnection(object):
         :param batch_size: max limit of Lambda event process in one time
         :param start_position: option for Lambda reading event mode
         :param filters: Optional[list]
-        :param enable_batch_report_failures: Optional[bool] enables batch item failures
+        :param function_response_types: Optional[list] list of function response types
         :return: response
         """
         params = dict(
@@ -310,8 +310,8 @@ class LambdaConnection(object):
             params['StartingPosition'] = start_position
         if filters:
             params['FilterCriteria'] = {'Filters': filters}
-        if enable_batch_report_failures is not None and enable_batch_report_failures:
-            params['FunctionResponseTypes'] = ['ReportBatchItemFailures']
+        if function_response_types:
+            params['FunctionResponseTypes'] = function_response_types
         response = self.client.create_event_source_mapping(**params)
         return response
 
@@ -502,7 +502,7 @@ class LambdaConnection(object):
 
     def update_event_source(self, uuid, function_name, batch_size,
                             batch_window=None, filters: Optional[List] = None,
-                            enable_batch_report_failures=None):
+                            function_response_types=None):
         params = dict(
             UUID=uuid, FunctionName=function_name, BatchSize=batch_size
         )
@@ -510,8 +510,8 @@ class LambdaConnection(object):
             params['MaximumBatchingWindowInSeconds'] = batch_window
         if filters is not None:
             params['FilterCriteria'] = {'Filters': filters}
-        if enable_batch_report_failures is not None and enable_batch_report_failures:
-            params['FunctionResponseTypes'] = ['ReportBatchItemFailures']
+        if function_response_types:
+            params['FunctionResponseTypes'] = function_response_types
         else:
             params['FunctionResponseTypes'] = []
         return self.client.update_event_source_mapping(**params)

--- a/syndicate/core/generators/contents.py
+++ b/syndicate/core/generators/contents.py
@@ -71,7 +71,7 @@ JAVA_ROOT_POM_TEMPLATE = """<?xml version="1.0" encoding="UTF-8"?>
 
     <properties>
         <maven-shade-plugin.version>3.5.2</maven-shade-plugin.version>
-        <syndicate.java.plugin.version>1.11.1</syndicate.java.plugin.version>
+        <syndicate.java.plugin.version>1.12.0</syndicate.java.plugin.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/syndicate/core/resources/lambda_resource.py
+++ b/syndicate/core/resources/lambda_resource.py
@@ -842,6 +842,7 @@ class LambdaResource(BaseResource):
                                       trigger_meta):
         validate_params(lambda_name, trigger_meta, SQS_TRIGGER_REQUIRED_PARAMS)
         target_queue = trigger_meta['target_queue']
+        enable_batch_report_failures = trigger_meta.get("enable_batch_report_failures", False)
         batch_size, batch_window = self._resolve_batch_size_batch_window(
             trigger_meta)
 
@@ -862,10 +863,12 @@ class LambdaResource(BaseResource):
             self.lambda_conn.update_event_source(
                 event_source['UUID'], function_name=lambda_arn,
                 batch_size=batch_size,
-                batch_window=batch_window)
+                batch_window=batch_window,
+                enable_batch_report_failures=enable_batch_report_failures)
         else:
             self.lambda_conn.add_event_source(
-                lambda_arn, queue_arn, batch_size, batch_window
+                lambda_arn, queue_arn, batch_size, batch_window,
+                enable_batch_report_failures=enable_batch_report_failures
             )
 
         _LOG.info('Lambda %s subscribed to SQS queue %s', lambda_name,

--- a/syndicate/core/resources/lambda_resource.py
+++ b/syndicate/core/resources/lambda_resource.py
@@ -842,7 +842,8 @@ class LambdaResource(BaseResource):
                                       trigger_meta):
         validate_params(lambda_name, trigger_meta, SQS_TRIGGER_REQUIRED_PARAMS)
         target_queue = trigger_meta['target_queue']
-        enable_batch_report_failures = trigger_meta.get("enable_batch_report_failures", False)
+        function_response_types = trigger_meta.get(
+            "function_response_types", [])
         batch_size, batch_window = self._resolve_batch_size_batch_window(
             trigger_meta)
 
@@ -864,11 +865,11 @@ class LambdaResource(BaseResource):
                 event_source['UUID'], function_name=lambda_arn,
                 batch_size=batch_size,
                 batch_window=batch_window,
-                enable_batch_report_failures=enable_batch_report_failures)
+                function_response_types=function_response_types)
         else:
             self.lambda_conn.add_event_source(
                 lambda_arn, queue_arn, batch_size, batch_window,
-                enable_batch_report_failures=enable_batch_report_failures
+                function_response_types=function_response_types
             )
 
         _LOG.info('Lambda %s subscribed to SQS queue %s', lambda_name,


### PR DESCRIPTION
# Why ?
This pull request closes #372, it gives possibility to use this [code](https://docs.aws.amazon.com/lambda/latest/dg/example_serverless_SQS_Lambda_batch_item_failures_section.html), because without these changes report batch failures is disabled, and the only way to enable it is to manual interaction with AWS console.
The subject property here is this (in lambda triggers in AWS console):
![image](https://github.com/epam/aws-syndicate/assets/28604463/f19c1880-7ddc-4d6c-9f64-2a5fdc3824ab)
It's highlighted with red color. 
# What I changed ?
I modified classes related to maven plugin, and also added additional property with default value false in SqsTriggerEventSource java annotation. Also modified two python files, related to processing properties from sqs triggers resources, with backward compatibility.
# Test plan
* create sqs queue and attach it via SqsEvents and SqsTriggerEventSource annotations
* SqsTriggerEventSource has new property enableBatchReportFailures, which is by default set to false in the annotation declaration, so there should be no compilation errors
* execute `syndicate build && syndicate deploy` commands, the property should be set to "No" in the aws console, as in the screenshot above
* change enableBatchReportFailures to true in your annotation for sqs handler class, and execute `syndicate build && syndicate update` commands, now the property should be set to "Yes"
* execute `syndicate clean && syndicate build && syndicate deploy`, the property still should be set to "Yes" in AWS console