### PR TITLE
fix tabulation

### DIFF
--- a/syndicate/connection/s3_connection.py
+++ b/syndicate/connection/s3_connection.py
@@ -217,7 +217,7 @@ class S3Connection(object):
                         }
                     }
                 })
-                config['LambdaFunctionConfigurations'].append(params)
+            config['LambdaFunctionConfigurations'].append(params)
 
         self.client.put_bucket_notification_configuration(
             Bucket=bucket,


### PR DESCRIPTION
Fixed wrong tabulation which could lead to ignoring s3 triggers configured for lambdas which had no filter rules attribute.