### PR TITLE
Operation Status fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [1.13.2] - 2024-07-10
+- A check has been added to see if `operation_status` exists in the `latest_deploy` record in `.syndicate` file to ensure that users from the previous version can continue using the syndicate.
+
 # [1.13.1] - 2024-07-09
 - Changed datetime format for lock attributes in the `.syndicate` file to UTC format
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='aws-syndicate',
-    version='1.13.1',
+    version='1.13.2',
     packages=find_packages(),
     include_package_data=True,
     install_requires=[

--- a/syndicate/core/build/bundle_processor.py
+++ b/syndicate/core/build/bundle_processor.py
@@ -138,6 +138,19 @@ def load_latest_deploy_output():
     bundle_name = PROJECT_STATE.latest_deploy.get('bundle_name')
     latest_deploy_status = PROJECT_STATE.latest_deploy.get('operation_status')
 
+    # Temporary code for syndicate 1.11.6 > 1.12.0 update
+    if latest_deploy_status is None:
+        _LOG.warn("You came from a previous version and there is no"
+                  " operation_status field in the latest_deploy record in"
+                  " your .syndicate file, it will be determined automatically,"
+                  " the syndicate will analyze your previous deploy and"
+                  " determine the value of operation_status.")
+        try:
+            load_deploy_output(bundle_name, deploy_name)
+            latest_deploy_status = True
+        except AssertionError:
+            latest_deploy_status = False
+
     if latest_deploy_status is True:
         return load_deploy_output(bundle_name, deploy_name)
     else:


### PR DESCRIPTION
A check has been added to see if `operation_status` exists in the `latest_deploy` record in `.syndicate` file to ensure that users from the previous version can continue using the syndicate.
