### PR TITLE
[EPMCEOOS-6079] Feature/improve deploy continue deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [1.14.0] - 2024-07-25
+- The key `operation_status` in `latest_deploy` section of the syndicate state file(.syndicate) renamed to `is_succeeded`
+- Changed deployment flow to work despite the latest deployment failed
+- Changed deployment flow with the flag `--continue_deploy` to work despite the latest deployment being absent or succeeded
+- Implemented rolling back on error mechanism(flag `--rollback_on_error`) for deployment flow with the flag `--continue_deploy`
+- Added confirmation request mechanism for the `update` command in case the latest deployment failed
+- Added the flag `--force` for the `update` command to run an update without confirmation request in case the latest deployment failed
+- Added proper messages for commands `update` and `clean` if deployed resources are absent(output file not found)
+
 # [1.13.0] - 2024-07-10
 - Added possibility to configure `FunctionResponseTypes` for lambda functions
 - Updated maven plugin version to 1.12.0 with support of `FunctionResponseTypes`

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='aws-syndicate',
-    version='1.13.0',
+    version='1.14.0',
     packages=find_packages(),
     include_package_data=True,
     install_requires=[

--- a/syndicate/core/build/deployment_processor.py
+++ b/syndicate/core/build/deployment_processor.py
@@ -532,8 +532,9 @@ def remove_deployment_resources(deploy_name, bundle_name,
                 bundle_name, deploy_name
             )
             is_regular_output = False
-        except AssertionError as e:
-            return e
+        except AssertionError:
+            USER_LOG.error("Deployment to clean not found.")
+            return ABORTED_STATUS
 
     clean_only_resources = _resolve_names(clean_only_resources)
     excluded_resources = _resolve_names(excluded_resources)

--- a/syndicate/core/constants.py
+++ b/syndicate/core/constants.py
@@ -210,3 +210,5 @@ SYNDICATE_PROJECT_EXAMPLES_PAGE = 'https://github.com/epam/aws-syndicate/tree/ma
 JAVA_LAMBDAS_WIKI_PAGE = '3.-Lambda-Requirements-for-Automatic-Articfacts-Build#32-java-lambdas'
 
 EC2_LAUNCH_TEMPLATE_SUPPORTED_IMDS_VERSIONS = ['v1.0', 'v2.0']
+
+ABORTED_STATUS = 'aborted'

--- a/syndicate/core/handlers.py
+++ b/syndicate/core/handlers.py
@@ -433,7 +433,11 @@ def clean(deploy_name, bundle_name, clean_only_types, clean_only_resources,
         excluded_types=excluded_types,
         clean_externals=clean_externals,
         preserve_state=preserve_state)
-    click.echo('AWS resources were removed.')
+
+    if result == ABORTED_STATUS:
+        click.echo('Clean of resources has been aborted')
+    else:
+        click.echo('AWS resources were removed.')
     return result
 
 

--- a/syndicate/core/handlers.py
+++ b/syndicate/core/handlers.py
@@ -73,7 +73,8 @@ from syndicate.core.constants import TEST_ACTION, BUILD_ACTION, \
     STATUS_ACTION, WARMUP_ACTION, PROFILER_ACTION, ASSEMBLE_JAVA_MVN_ACTION, \
     ASSEMBLE_PYTHON_ACTION, ASSEMBLE_NODE_ACTION, ASSEMBLE_ACTION, \
     PACKAGE_META_ACTION, CREATE_DEPLOY_TARGET_BUCKET_ACTION, UPLOAD_ACTION, \
-    COPY_BUNDLE_ACTION, EXPORT_ACTION, ASSEMBLE_SWAGGER_UI_ACTION
+    COPY_BUNDLE_ACTION, EXPORT_ACTION, ASSEMBLE_SWAGGER_UI_ACTION, \
+    ABORTED_STATUS
 
 INIT_COMMAND_NAME = 'init'
 SYNDICATE_PACKAGE_NAME = 'aws-syndicate'
@@ -313,13 +314,16 @@ def deploy(deploy_name, bundle_name, deploy_only_types, deploy_only_resources,
               help='Types of the resources to skip while update')
 @click.option('--replace_output', nargs=1, is_flag=True, default=False,
               help='The flag to replace the existing deploy output file')
+@click.option('--force', nargs=1, is_flag=True, default=False,
+              help='The flag, to apply updates even if the latest deployment '
+                   'failed')
 @verbose_option
 @check_deploy_name_for_duplicates
 @check_deploy_bucket_exists
 @timeit(action_name=UPDATE_ACTION)
 def update(bundle_name, deploy_name, replace_output, update_only_resources,
            update_only_resources_path, update_only_types, excluded_resources,
-           excluded_resources_path, excluded_types):
+           excluded_resources_path, excluded_types, force):
     """
     Updates infrastructure from the provided bundle
     """
@@ -349,9 +353,12 @@ def update(bundle_name, deploy_name, replace_output, update_only_resources,
         update_only_resources=update_only_resources,
         excluded_resources=excluded_resources,
         excluded_types=excluded_types,
-        replace_output=replace_output)
-    if success:
+        replace_output=replace_output,
+        force=force)
+    if success is True:
         click.echo('Update of resources has been successfully completed')
+    elif success == ABORTED_STATUS:
+        click.echo('Update of resources has been aborted')
     else:
         click.echo('Something went wrong during resources update')
 

--- a/syndicate/core/handlers.py
+++ b/syndicate/core/handlers.py
@@ -228,8 +228,7 @@ def transform(bundle_name, dsl, output_dir):
               help='Flag to replace the existing deploy output')
 @click.option('--rollback_on_error', is_flag=True, default=False,
               help='Flag to automatically clean deployed resources if the'
-                   ' deployment is unsuccessful. Cannot be used with'
-                   ' --continue_deploy flag.')
+                   ' deployment is unsuccessful')
 @verbose_option
 @check_deploy_name_for_duplicates
 @check_deploy_bucket_exists

--- a/syndicate/core/helper.py
+++ b/syndicate/core/helper.py
@@ -348,7 +348,7 @@ def timeit(action_name=None):
                 bundle_name = kwargs.get('bundle_name')
                 deploy_name = kwargs.get('deploy_name')
                 rollback_on_error = kwargs.get('rollback_on_error')
-                operation_status = result
+                is_succeeded = result
                 from syndicate.core import PROJECT_STATE
                 PROJECT_STATE.log_execution_event(
                     operation=result_action_name or action_name,
@@ -358,7 +358,7 @@ def timeit(action_name=None):
                     time_start=start_date_formatted,
                     time_end=end_date_formatted,
                     duration_sec=duration,
-                    operation_status=operation_status,
+                    is_succeeded=is_succeeded,
                     rollback_on_error=rollback_on_error
                 )
             return result

--- a/syndicate/core/project_state/project_state.py
+++ b/syndicate/core/project_state/project_state.py
@@ -361,16 +361,16 @@ class ProjectState:
     def log_execution_event(self, **kwargs):
         operation = kwargs.get('operation')
 
-        operation_status = kwargs.get('operation_status')
+        is_succeeded = kwargs.get('is_succeeded')
         rollback_on_error = kwargs.get('rollback_on_error')
-        if not isinstance(operation_status, bool):
-            kwargs.pop('operation_status')
+        if not isinstance(is_succeeded, bool):
+            kwargs.pop('is_succeeded')
 
         if operation in [DEPLOY_ACTION, PARTIAL_CLEAN_ACTION]:
             params = kwargs.copy()
             params.pop('operation')
 
-            if not(operation_status is False and rollback_on_error is True):
+            if not (is_succeeded is False and rollback_on_error is True):
                 params.pop('rollback_on_error')
                 self._set_latest_deploy_info(**params)
 


### PR DESCRIPTION
- The key `operation_status` in `latest_deploy` section of the syndicate state file(.syndicate) renamed to `is_succeeded`
- Changed deployment flow to work despite the latest deployment failed
- Changed deployment flow with the flag `--continue_deploy` to work despite the latest deployment being absent or succeeded
- Implemented rolling back on error mechanism(flag `--rollback_on_error`) for deployment flow with the flag `--continue_deploy`
- Added confirmation request mechanism for the `update` command in case the latest deployment failed
- Added the flag `--force` for the `update` command to run an update without confirmation request in case the latest deployment failed
- Added proper messages for commands `update` and `clean` if deployed resources are absent(output file not found)
