### PR TITLE
Resource name in error logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# [1.14.1] - 2024-08-07
+# [1.14.1] - 2024-08-08
 - Added logging of resource names that cause errors to improve error diagnostics
+- Fix the resource update issue that occurs when a deploy_name is specified without deployment output from the latest deployment
+- Fixed an issue where updating only certain resources caused the deployment output to be overwritten with only these 
+resources, instead of updating the existing meta
 
 # [1.14.0] - 2024-07-25
 - The key `operation_status` in `latest_deploy` section of the syndicate state file(.syndicate) renamed to `is_succeeded`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [1.14.1] - 2024-08-07
+- Added logging of resource names that cause errors to improve error diagnostics
+
 # [1.14.0] - 2024-07-25
 - The key `operation_status` in `latest_deploy` section of the syndicate state file(.syndicate) renamed to `is_succeeded`
 - Changed deployment flow to work despite the latest deployment failed

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='aws-syndicate',
-    version='1.14.0',
+    version='1.14.1',
     packages=find_packages(),
     include_package_data=True,
     install_requires=[

--- a/syndicate/core/build/bundle_processor.py
+++ b/syndicate/core/build/bundle_processor.py
@@ -30,6 +30,13 @@ from syndicate.core.helper import build_path, unpack_kwargs
 
 _LOG = get_logger('syndicate.core.build.bundle_processor')
 
+CURRENT_BUNDLE_NAME = None
+
+
+def update_bundle_name(name):
+    global CURRENT_BUNDLE_NAME
+    CURRENT_BUNDLE_NAME = name
+
 
 def _build_output_key(bundle_name, deploy_name, is_regular_output):
     return '{0}/outputs/{1}{2}.json'.format(

--- a/syndicate/core/handlers.py
+++ b/syndicate/core/handlers.py
@@ -61,8 +61,7 @@ from syndicate.core.helper import (create_bundle_callback,
                                    resolve_default_value, ValidRegionParamType,
                                    generate_default_bundle_name,
                                    resolve_and_verify_bundle_callback,
-                                   param_to_lower, verbose_option,
-                                   validate_incompatible_options)
+                                   param_to_lower, verbose_option)
 from syndicate.core.project_state.project_state import (MODIFICATION_LOCK,
                                                         WARMUP_LOCK)
 from syndicate.core.project_state.status_processor import project_state_status

--- a/syndicate/core/handlers.py
+++ b/syndicate/core/handlers.py
@@ -32,10 +32,11 @@ from syndicate.core.build.artifact_processor import (RUNTIME_NODEJS,
 from syndicate.core.build.bundle_processor import (create_bundles_bucket,
                                                    load_bundle,
                                                    upload_bundle_to_s3,
-                                                   if_bundle_exist)
+                                                   if_bundle_exist,
+                                                   update_bundle_name)
 from syndicate.core.build.deployment_processor import (
     create_deployment_resources, remove_deployment_resources,
-    update_deployment_resources)
+    update_deployment_resources, update_deployment_name)
 from syndicate.core.build.meta_processor import create_meta
 from syndicate.core.build.profiler_processor import (get_metric_statistics,
                                                      process_metrics)
@@ -239,6 +240,9 @@ def deploy(deploy_name, bundle_name, deploy_only_types, deploy_only_resources,
     """
     Deploys the application infrastructure
     """
+    update_bundle_name(bundle_name)
+    update_deployment_name(deploy_name)
+
     if deploy_only_resources_path and os.path.exists(
             deploy_only_resources_path):
         deploy_resources_list = json.load(open(deploy_only_resources_path))
@@ -313,6 +317,8 @@ def update(bundle_name, deploy_name, replace_output, update_only_resources,
     Updates infrastructure from the provided bundle
     """
     click.echo(f'Bundle name: {bundle_name}')
+    update_bundle_name(bundle_name)
+    update_deployment_name(deploy_name)
 
     if update_only_resources_path and os.path.exists(
             update_only_resources_path):
@@ -387,6 +393,10 @@ def clean(deploy_name, bundle_name, clean_only_types, clean_only_resources,
     click.echo('Command clean')
     click.echo(f'Deploy name: {deploy_name}')
     separator = ', '
+
+    update_bundle_name(bundle_name)
+    update_deployment_name(deploy_name)
+
     if clean_only_types:
         click.echo(f'Clean only types: {separator.join(clean_only_types)}')
     if clean_only_resources:

--- a/syndicate/core/helper.py
+++ b/syndicate/core/helper.py
@@ -198,7 +198,7 @@ def generate_default_bundle_name(ctx, param, value):
 
 def resolve_default_bundle_name(command_name):
     from syndicate.core import PROJECT_STATE
-    if command_name == 'clean':
+    if command_name in ('clean', 'update'):
         bundle_name = PROJECT_STATE.latest_deployed_bundle_name
     else:
         bundle_name = PROJECT_STATE.latest_bundle_name
@@ -212,7 +212,7 @@ def resolve_default_bundle_name(command_name):
 
 def resolve_default_deploy_name(command_name):
     from syndicate.core import PROJECT_STATE
-    if command_name == 'clean':
+    if command_name in ('clean', 'update'):
         deploy_name = PROJECT_STATE.latest_deployed_deploy_name
     else:
         deploy_name = PROJECT_STATE.default_deploy_name

--- a/syndicate/core/resources/lambda_resource.py
+++ b/syndicate/core/resources/lambda_resource.py
@@ -1115,13 +1115,15 @@ class LambdaResource(BaseResource):
             func(self, name, arn, role_name, event_source)
 
     def update_lambda_triggers(self, name, arn, role_name, event_sources_meta):
-        from syndicate.core import CONFIG, PROJECT_STATE
+        from syndicate.core import CONFIG
+        from syndicate.core.build.bundle_processor import CURRENT_BUNDLE_NAME
+        from syndicate.core.build.deployment_processor import \
+            CURRENT_DEPLOYMENT_NAME
 
-        # load latest output to compare it with current event sources
-        deploy_name = PROJECT_STATE.latest_deploy.get('deploy_name')
-        bundle_name = PROJECT_STATE.latest_modification.get('bundle_name')
+        # load previous output to compare it with current event sources
         key = _build_output_key(
-            bundle_name=bundle_name, deploy_name=deploy_name,
+            bundle_name=CURRENT_BUNDLE_NAME,
+            deploy_name=CURRENT_DEPLOYMENT_NAME,
             is_regular_output=True)
         key_compound = PurePath(
             CONFIG.deploy_target_bucket_key_compound, key).as_posix()


### PR DESCRIPTION
- Added logging of resource names that cause errors to improve error diagnostics
- Fix the resource update issue that occurs when a deploy_name is specified by user (not default one) but deployment 
output for the latest deployment is empty
- Fixed an issue where updating only certain resources caused the deployment output to be overwritten with only these 
resources, instead of updating the existing meta
