### PR TITLE
Fixed silent overwriting lambda with runtime Java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tagging added to `oas_v3 openapi` API Gateway.
 - SNS topic deletion fixed.
 - Added an example of a lambda function with runtime `dotnet`
+- Fixed silent overwriting existing lambda with runtime Java during the command `syndicate generate lambda`
 
 # [1.14.0] - 2024-08-28
 - Changed deployment flow to work despite the latest deployment failed

--- a/syndicate/core/generators/lambda_function.py
+++ b/syndicate/core/generators/lambda_function.py
@@ -284,6 +284,7 @@ def __lambda_name_to_class_name(lambda_name):
 
 
 def _generate_java_lambdas(**kwargs):
+    from click import confirm as click_confirm
     project_path = kwargs.get(PROJECT_PATH_PARAM)
     project_state = kwargs.get(PROJECT_STATE_PARAM)
     project_name = project_state.name
@@ -325,6 +326,12 @@ def _generate_java_lambdas(**kwargs):
         java_handler_file_name = os.path.join(
             project_path, SRC_MAIN_JAVA, java_package_as_path,
             f'{lambda_class_name}.java')
+        if Path(str(java_handler_file_name)).is_file():
+            if not click_confirm(
+                    f'\nLambda {lambda_name} already exists.\nOverride '
+                    f'the Lambda function?'):
+                _LOG.info(CANCEL_MESSAGE.format(lambda_name))
+                continue
         _write_content_to_file(
             java_handler_file_name,
             java_handler_content


### PR DESCRIPTION
Fixed silent overwriting existing lambda with runtime Java during the command `syndicate generate lambda`