### PR TITLE
Improve --errors_allowed option and add --skip_tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ building the bundle
 - Improved logic of option `--errors_allowed` to allow dependency installing if it is not possible to find a 
 requirement that fits a specific platform. In this case, the dependencies will be installed independently 
 of each other or without specifying a specific platform (using default platform `any`). Python-specific feature
-
-# [1.14.2] - 2024-10-25
 - Fixed updating lambda layers when the lambda no longer has layers
 - Fixed logging not found exceptions during the clean operation
 - Fixed handling of deployment output in case of failures on the stage describe resources in case of deploy/update fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [1.15.0] - 2024-10-28
+- Added `--skip_tests` option to `build`, `test` and `assemble_java_mvn` commands to not run tests during or after 
+building the bundle
+- Added `--errors_allowed` option to `assemble_python` and `assemble` commands
+- Improved logic of option `--errors_allowed` to allow dependency installing if it is not possible to find a 
+requirement that fits a specific platform. In this case, the dependencies will be installed independently 
+of each other or without specifying a specific platform (using default platform `any`). Python-specific feature
+
 # [1.14.2] - 2024-10-16
 - Fixed updating lambda layers when the lambda no longer has layers
 - Improved error message if errors occur during Python requirements installation

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='aws-syndicate',
-    version='1.14.2',
+    version='1.15.0',
     packages=find_packages(),
     include_package_data=True,
     install_requires=[

--- a/syndicate/core/build/artifact_processor.py
+++ b/syndicate/core/build/artifact_processor.py
@@ -49,12 +49,12 @@ RUNTIME_TO_BUILDER_MAPPING = {
 _LOG = get_logger('syndicate.core.build.artifact_processor')
 
 
-def assemble_artifacts(bundle_name, project_path, runtime, force_upload=None):
+def assemble_artifacts(bundle_name, project_path, runtime, force_upload=None,
+                       errors_allowed=False, skip_tests=False):
     if runtime not in SUPPORTED_RUNTIMES:
         raise AssertionError(
-            'Runtime {} is not supported. '
-            'Currently available runtimes:{}'.format(runtime,
-                                                     SUPPORTED_RUNTIMES))
+            f'Runtime {runtime} is not supported. '
+            f'Currently available runtimes:{SUPPORTED_RUNTIMES}')
 
     bundle_dir = resolve_bundle_directory(bundle_name=bundle_name)
 
@@ -69,11 +69,13 @@ def assemble_artifacts(bundle_name, project_path, runtime, force_upload=None):
             shutil.rmtree(normalized_bundle_dir)
 
     os.makedirs(bundle_dir, exist_ok=True)
-    _LOG.debug('Target directory: {0}'.format(bundle_dir))
+    _LOG.debug(f'Target directory: {bundle_dir}')
 
     assemble_func = RUNTIME_TO_BUILDER_MAPPING.get(runtime)
     if not assemble_func:
         raise AssertionError(
-            'There is no assembler for the runtime {}'.format(runtime))
+            f'There is no assembler for the runtime {runtime}')
     assemble_func(project_path=project_path,
-                  bundles_dir=bundle_dir)
+                  bundles_dir=bundle_dir,
+                  errors_allowed=errors_allowed,
+                  skip_tests=skip_tests)

--- a/syndicate/core/build/runtime/dotnet.py
+++ b/syndicate/core/build/runtime/dotnet.py
@@ -58,7 +58,7 @@ _LOG = get_logger('dotnet_runtime_assembler')
 USER_LOG = get_user_logger()
 
 
-def assemble_dotnet_lambdas(project_path, bundles_dir):
+def assemble_dotnet_lambdas(project_path, bundles_dir, **kwargs):
     from syndicate.core import CONFIG
 
     _check_dotnet_is_installed()

--- a/syndicate/core/build/runtime/java.py
+++ b/syndicate/core/build/runtime/java.py
@@ -24,14 +24,16 @@ _LOG = get_logger('java_runtime_assembler')
 MVN_TARGET_DIRECTORY = 'target'
 
 
-def assemble_java_mvn_lambdas(project_path, bundles_dir):
+def assemble_java_mvn_lambdas(project_path, bundles_dir, skip_tests=False,
+                              **kwargs):
     from syndicate.core import CONFIG
     src_path = build_path(CONFIG.project_path, project_path)
     _LOG.info(f'Java sources are located by path: {src_path}')
     _LOG.info(f'Going to process java mvn project by path: '
               f'{CONFIG.project_path}')
-    execute_command_by_path(command='mvn clean install',
-                            path=CONFIG.project_path)
+    execute_command_by_path(
+        command='mvn clean install' + ' -DskipTests' if skip_tests else '',
+        path=CONFIG.project_path)
 
     # copy java artifacts to the target folder
     for root, dirs, files in os.walk(os.path.join(CONFIG.project_path,

--- a/syndicate/core/build/runtime/nodejs.py
+++ b/syndicate/core/build/runtime/nodejs.py
@@ -52,7 +52,7 @@ def _copy_js_files(search_path, destination_path):
             shutil.copy2(js_file, destination_path)
 
 
-def assemble_node_lambdas(project_path, bundles_dir):
+def assemble_node_lambdas(project_path, bundles_dir, **kwargs):
     from syndicate.core import CONFIG
     project_abs_path = Path(CONFIG.project_path, project_path)
     _LOG.info(f'Going to package lambdas starting by path {project_abs_path}')

--- a/syndicate/core/build/runtime/python.py
+++ b/syndicate/core/build/runtime/python.py
@@ -199,21 +199,30 @@ def install_requirements_to(requirements_txt: Union[str, Path],
     1. If there is NO "platform" parameter in lambda_config.json, then the
     dependency installation will be executed by the default command:
     "pip install -r requirements.txt".
+
     2. If there is NO "platform" parameter in lambda_config.json and flag
-    --errors_allowed is True, then installation of dependencies will be
-    performed separately for each dependency using the default command:
+    --errors_allowed is True, dependency installation will be tried by
+    executing the default command: "pip install -r requirements.txt" in case
+    of failures, installation of dependencies will be performed separately
+    for each dependency using the default command:
     "pip install <package1>
     pip install <packageN>".
+
     3. If there is "platform" parameter in lambda_config.json and flag
     --errors_allowed is False, then the dependency installation will be
     executed by the default command using additional parameters:
     "pip install -r requirements.txt --platform manylinux2014_x86_64
     --only-binary=:all: --implementation=cp --python-version 3.8".
+
     4. If there is "platform" parameter in lambda_config.json and flag
-    --errors_allowed is True, then installation of dependencies will be
-    performed separately for each dependency using the default command using
-    additional parameters. Dependencies that do not have a specified platform
-    will be installed with the --platform=any:
+    --errors_allowed is True, dependency installation will be tried by the
+    default command using additional parameters:
+    "pip install -r requirements.txt --platform manylinux2014_x86_64
+    --only-binary=:all: --implementation=cp --python-version 3.8",
+    in case of failures, installation of dependencies will be performed
+    separately for each dependency using the default command using additional
+    parameters. Dependencies that do not have a specified platform will be
+    installed with the --platform=any:
     "pip install <package1> --platform manylinux2014_x86_64
     --only-binary=:all: --implementation=cp --python-version 3.8
     pip install <packageN> --platform manylinux2014_x86_64

--- a/syndicate/core/build/runtime/swagger_ui.py
+++ b/syndicate/core/build/runtime/swagger_ui.py
@@ -30,7 +30,7 @@ _LOG = get_logger('syndicate.core.generators.swagger_ui')
 USER_LOG = get_user_logger()
 
 
-def assemble_swagger_ui(project_path, bundles_dir):
+def assemble_swagger_ui(project_path, bundles_dir, **kwargs):
     from syndicate.core import CONFIG
     path_to_project = CONFIG.project_path
     src_path = build_path(path_to_project, project_path)

--- a/syndicate/core/handlers.py
+++ b/syndicate/core/handlers.py
@@ -166,11 +166,14 @@ def test(suite, test_folder_name, errors_allowed, skip_tests):
     if result.returncode != 0:
         _LOG.error(f'{result.stdout}\n{result.stderr}\n{"-" * 70}')
         if not errors_allowed:
-            click.echo('Some tests failed. Exiting.')
+            click.echo(
+                'Some tests failed. See details in the log file. Exiting...')
             sys.exit(result.returncode)
-
-    _LOG.info(f'{result.stdout}\n{result.stderr}\n{"-" * 70}')
-    click.echo('Tests passed.')
+        else:
+            USER_LOG.warn('Some tests failed. See details in the log file.')
+    else:
+        _LOG.info(f'{result.stdout}\n{result.stderr}\n{"-" * 70}')
+        click.echo('Tests passed.')
 
 
 @syndicate.command(name=BUILD_ACTION)

--- a/syndicate/core/handlers.py
+++ b/syndicate/core/handlers.py
@@ -653,7 +653,7 @@ def profiler(bundle_name, deploy_name, from_date, to_date):
 @verbose_option
 @timeit(action_name=ASSEMBLE_JAVA_MVN_ACTION)
 def assemble_java_mvn(bundle_name, project_path, force_upload, skip_tests,
-                      **kwargs):
+                      errors_allowed=False):
     """
     Builds Java lambdas
 
@@ -662,6 +662,8 @@ def assemble_java_mvn(bundle_name, project_path, force_upload, skip_tests,
     :param project_path: path to project folder
     :param force_upload: force upload identification
     :param skip_tests: force skipping tests
+    :param errors_allowed: not used for java, but need to unify the
+    `assemble` commands interface
     :return:
     """
     click.echo(f'Command compile java project path: {project_path}')
@@ -697,7 +699,8 @@ def assemble_java_mvn(bundle_name, project_path, force_upload, skip_tests,
                    'while building dependencies')
 @verbose_option
 @timeit(action_name=ASSEMBLE_PYTHON_ACTION)
-def assemble_python(bundle_name, project_path, force_upload, errors_allowed):
+def assemble_python(bundle_name, project_path, force_upload, errors_allowed,
+                    skip_tests=False):
     """
     Builds Python lambdas
 
@@ -706,6 +709,8 @@ def assemble_python(bundle_name, project_path, force_upload, errors_allowed):
     :param project_path: path to project folder
     :param force_upload: force upload identification
     :param errors_allowed: allows to ignore dependency errors
+    :param skip_tests: not used for python, but need to unify the
+    `assemble` commands interface
     :return:
     """
     click.echo(f'Command assemble python: project_path: {project_path} ')
@@ -736,7 +741,8 @@ def assemble_python(bundle_name, project_path, force_upload, errors_allowed):
                    ' the same path.')
 @verbose_option
 @timeit(action_name=ASSEMBLE_NODE_ACTION)
-def assemble_node(bundle_name, project_path, force_upload, **kwargs):
+def assemble_node(bundle_name, project_path, force_upload,
+                  errors_allowed=False, skip_tests=False):
     """
     Builds NodeJS lambdas
 
@@ -744,6 +750,10 @@ def assemble_node(bundle_name, project_path, force_upload, **kwargs):
     :param bundle_name: name of the bundle
     :param project_path: path to project folder
     :param force_upload: force upload identification
+    :param errors_allowed: not used for NodeJS, but need to unify the
+    `assemble` commands interface
+    :param skip_tests: not used for NodeJS, but need to unify the
+    `assemble` commands interface
     :return:
     """
     click.echo(f'Command assemble node: project_path: {project_path} ')
@@ -774,7 +784,8 @@ def assemble_node(bundle_name, project_path, force_upload, **kwargs):
                    ' the same path.')
 @verbose_option
 @timeit(action_name=ASSEMBLE_DOTNET_ACTION)
-def assemble_dotnet(bundle_name, project_path, force_upload, **kwargs):
+def assemble_dotnet(bundle_name, project_path, force_upload,
+                    errors_allowed=False, skip_tests=False):
     """
     Builds DotNet lambdas
 
@@ -782,6 +793,10 @@ def assemble_dotnet(bundle_name, project_path, force_upload, **kwargs):
     :param bundle_name: name of the bundle
     :param project_path: path to project folder
     :param force_upload: force upload identification
+    :param errors_allowed: not used for DotNet, but need to unify the
+    `assemble` commands interface
+    :param skip_tests: not used for DotNet, but need to unify the
+    `assemble` commands interface
     :return:
     """
     click.echo(f'Command assemble dotnet: project_path: {project_path} ')


### PR DESCRIPTION
- Added `--skip_tests` option to `build`, `test` and `assemble_java_mvn` commands to not run tests during or after 
building the bundle
- Added `--errors_allowed` option to `assemble_python` and `assemble` commands
- Improved logic of option `--errors_allowed` to allow dependency installing if it is not possible to find a 
requirement that fits a specific platform. In this case, the dependencies will be installed independently 
of each other or without specifying a specific platform (using default platform `any`). Python-specific feature