### PR TITLE
Fix `clean` command for `output` folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure `zip_dir` validates the existence of the base directory before proceeding with the zipping process
 - Fix `tag_resources` and `untag_resources` to handle exceptions properly
 - Update `apply_tags`, `remove_tags`, and `update_tags` to return success status
+- Fix `clean` command for `output` folder to correctly resolve ARN for Lambda and properly process and remove the `outputs` folder if Lambda is part of the deployment
+- Fix bucket name resolver to raise a user-friendly message if the bucket name does not match the specified regex
 
 # [1.15.0] - 2024-10-28
 - Added `--skip_tests` option to `build`, `test` and `assemble_java_mvn` commands to not run tests during or after 

--- a/syndicate/core/build/bundle_processor.py
+++ b/syndicate/core/build/bundle_processor.py
@@ -44,8 +44,13 @@ def _backup_deploy_output(filename, output):
         backup_file.close()
 
 
-def create_deploy_output(bundle_name, deploy_name, output, success,
-                         replace_output=False):
+def create_deploy_output(
+        bundle_name: str,
+        deploy_name: str,
+        output: dict,
+        success: bool,
+        replace_output: bool = False,
+) -> None:
     from syndicate.core import CONFIG, CONN
     _LOG.debug('Going to preprocess resources tags in output')
     preprocess_tags(output)
@@ -53,54 +58,64 @@ def create_deploy_output(bundle_name, deploy_name, output, success,
     key = _build_output_key(bundle_name=bundle_name,
                             deploy_name=deploy_name,
                             is_regular_output=success)
-    key_compound = PurePath(CONFIG.deploy_target_bucket_key_compound,
-                            key).as_posix()
-    if CONN.s3().is_file_exists(CONFIG.deploy_target_bucket,
-                                key_compound) and not replace_output:
-        _LOG.warn(
-            'Output file for deploy {0} already exists.'.format(deploy_name))
+    key_compound = \
+        PurePath(CONFIG.deploy_target_bucket_key_compound, key).as_posix()
+    if CONN.s3().is_file_exists(CONFIG.deploy_target_bucket, key_compound) \
+            and not replace_output:
+        _LOG.warning(f'Output file for deploy {deploy_name} already exists')
     else:
         CONN.s3().put_object(output_str, key_compound,
                              CONFIG.deploy_target_bucket,
                              'application/json')
-        _LOG.info('Output file with name {} has been {}'.format(
-            key, 'replaced' if replace_output else 'created'))
+        _LOG.info(
+            f"Output file with name {key} has been "
+            f"{'replaced' if replace_output else 'created'}"
+        )
 
 
-def remove_deploy_output(bundle_name, deploy_name):
+def remove_deploy_output(
+        bundle_name: str,
+        deploy_name: str,
+) -> None:
     from syndicate.core import CONFIG, CONN
     key = _build_output_key(bundle_name=bundle_name,
                             deploy_name=deploy_name,
                             is_regular_output=True)
-    key_compound = PurePath(CONFIG.deploy_target_bucket_key_compound,
-                            key).as_posix()
-    if CONN.s3().is_file_exists(CONFIG.deploy_target_bucket,
-                                key_compound):
+    key_compound = \
+        PurePath(CONFIG.deploy_target_bucket_key_compound, key).as_posix()
+    if CONN.s3().is_file_exists(CONFIG.deploy_target_bucket, key_compound):
         CONN.s3().remove_object(CONFIG.deploy_target_bucket, key_compound)
     else:
-        _LOG.warn(
-            'Output file for deploy {0} does not exist.'.format(deploy_name))
+        _LOG.warning(f'Output file for deploy {deploy_name} does not exist')
 
 
-def remove_failed_deploy_output(bundle_name, deploy_name):
+def remove_failed_deploy_output(
+        bundle_name: str,
+        deploy_name: str,
+) -> None:
     from syndicate.core import CONFIG, CONN
     key = _build_output_key(bundle_name=bundle_name,
                             deploy_name=deploy_name,
                             is_regular_output=False)
-    key_compound = PurePath(CONFIG.deploy_target_bucket_key_compound,
-                            key).as_posix()
-    if CONN.s3().is_file_exists(CONFIG.deploy_target_bucket,
-                                key_compound):
-        _LOG.debug(f"Going to remove failed output '{key_compound}' from the "
-                   f"bucket '{CONFIG.deploy_target_bucket}'")
+    key_compound = \
+        PurePath(CONFIG.deploy_target_bucket_key_compound, key).as_posix()
+    if CONN.s3().is_file_exists(CONFIG.deploy_target_bucket, key_compound):
+        _LOG.debug(
+            f"Going to remove failed output '{key_compound}' from the bucket "
+            f"'{CONFIG.deploy_target_bucket}'"
+        )
         CONN.s3().remove_object(CONFIG.deploy_target_bucket, key_compound)
     else:
-        _LOG.warn(
-            'Failed output file for deploy {0} does not exist.'.format(
-                deploy_name))
+        _LOG.warning(
+            f'Failed output file for deploy {deploy_name} does not exist'
+        )
 
 
-def load_deploy_output(bundle_name, deploy_name, failsafe: bool = False):
+def load_deploy_output(
+        bundle_name: str,
+        deploy_name: str,
+        failsafe: bool = False,
+) -> dict | bool:
     """
     :param bundle_name:
     :param deploy_name:
@@ -111,20 +126,22 @@ def load_deploy_output(bundle_name, deploy_name, failsafe: bool = False):
     key = _build_output_key(bundle_name=bundle_name,
                             deploy_name=deploy_name,
                             is_regular_output=True)
-    key_compound = PurePath(CONFIG.deploy_target_bucket_key_compound,
-                            key).as_posix()
-    if CONN.s3().is_file_exists(
-            CONFIG.deploy_target_bucket, key_compound):
-        output_file = CONN.s3().load_file_body(
-            CONFIG.deploy_target_bucket, key_compound)
+    key_compound = \
+        PurePath(CONFIG.deploy_target_bucket_key_compound, key).as_posix()
+    if CONN.s3().is_file_exists(CONFIG.deploy_target_bucket, key_compound):
+        output_file = \
+            CONN.s3().load_file_body(CONFIG.deploy_target_bucket, key_compound)
         return json.loads(output_file)
     else:
         if failsafe:
-            _LOG.warn(f'Deploy name {deploy_name} does not exist. '
-                      f'Failsafe status - {failsafe}.')
+            _LOG.warning(
+                f'Deploy name {deploy_name} does not exist. '
+                f'Failsafe status - {failsafe}'
+            )
             return False
-        raise AssertionError(f'Deploy name {deploy_name} does not exist. '
-                             f'Cannot find output file.')
+        raise AssertionError(
+            f'Deploy name {deploy_name} does not exist. Cannot find output file'
+        )
 
 
 def load_failed_deploy_output(bundle_name, deploy_name,
@@ -250,7 +267,7 @@ def create_bundles_bucket():
 def load_bundle(bundle_name, src_account_id, src_bucket_region,
                 src_bucket_name, role_name):
     from syndicate.core import CONFIG, RESOURCES_PROVIDER
-    _assert_bundle_bucket_exists()
+    assert_bundle_bucket_exists()
     try:
         _LOG.debug(
             'Going to assume {0} role from {1} account'.format(role_name,

--- a/syndicate/core/build/deployment_processor.py
+++ b/syndicate/core/build/deployment_processor.py
@@ -639,23 +639,23 @@ def update_deployment_resources(
 
 
 @exit_on_exception
-def remove_deployment_resources(deploy_name, bundle_name,
-                                clean_only_resources=None,
-                                clean_only_types=None,
-                                excluded_resources=None,
-                                excluded_types=None,
-                                clean_externals=None,
-                                preserve_state=None):
-
+def remove_deployment_resources(
+        deploy_name: str,
+        bundle_name: str,
+        clean_only_resources: tuple | None = None,
+        clean_only_types: tuple | None = None,
+        excluded_resources: tuple | None = None,
+        excluded_types: tuple | None = None,
+        clean_externals: bool = False,
+        preserve_state: bool = False,
+):
     is_regular_output = True
     try:
         output = load_deploy_output(bundle_name, deploy_name)
         _LOG.info('Output file was loaded successfully')
     except AssertionError:
         try:
-            output = load_failed_deploy_output(
-                bundle_name, deploy_name
-            )
+            output = load_failed_deploy_output(bundle_name, deploy_name)
             is_regular_output = False
         except AssertionError:
             USER_LOG.error("Deployment to clean not found.")
@@ -665,8 +665,7 @@ def remove_deployment_resources(deploy_name, bundle_name,
 
     clean_only_resources = _resolve_names(clean_only_resources)
     excluded_resources = _resolve_names(excluded_resources)
-    _LOG.info(
-        'Prefixes and suffixes of any resource names have been resolved.')
+    _LOG.info('Prefixes and suffixes of any resource names have been resolved')
 
     if clean_externals:
         new_output = {
@@ -701,17 +700,23 @@ def remove_deployment_resources(deploy_name, bundle_name,
     return _post_remove_output_handling(
         deploy_name=deploy_name,
         bundle_name=bundle_name,
-        preserve_state=preserve_state,
         output=output,
         new_output=new_output,
         is_regular_output=is_regular_output,
-        success=success
+        success=success,
+        preserve_state=preserve_state,
     )
 
 
-def _post_remove_output_handling(deploy_name, bundle_name, preserve_state,
-                                 output, new_output, is_regular_output,
-                                 success):
+def _post_remove_output_handling(
+        deploy_name: str,
+        bundle_name: str,
+        output: dict,
+        new_output: dict,
+        is_regular_output: bool,
+        success: bool,
+        preserve_state: bool = False,
+) -> bool | dict:
     if output == new_output:
         if not preserve_state:
             # remove output from bucket
@@ -727,9 +732,10 @@ def _post_remove_output_handling(deploy_name, bundle_name, preserve_state,
                              replace_output=True)
 
         if not success:
-            USER_LOG.warn(
-                "There were errors during the cleaning of resources. "
-                "More details can be found in the log file.")
+            USER_LOG.warning(
+                "There were errors during the cleaning of resources. More "
+                "details can be found in the log file"
+            )
             return success
         return {'operation': PARTIAL_CLEAN_ACTION}
     return success

--- a/syndicate/core/build/helper.py
+++ b/syndicate/core/build/helper.py
@@ -114,10 +114,9 @@ def resolve_bundle_directory(bundle_name):
     return build_path(resolve_all_bundles_directory(), bundle_name)
 
 
-def assert_bundle_bucket_exists():
+def assert_bundle_bucket_exists() -> None:
     from syndicate.core import CONFIG, CONN
-    if not CONN.s3().is_bucket_exists(
-            CONFIG.deploy_target_bucket):
+    if not CONN.s3().is_bucket_exists(CONFIG.deploy_target_bucket):
         raise AssertionError(
             f'Bundles bucket {CONFIG.deploy_target_bucket} does not exist. '
             f'Please use \'create_deploy_target_bucket\' to create the bucket.'

--- a/syndicate/core/handlers.py
+++ b/syndicate/core/handlers.py
@@ -434,9 +434,18 @@ def update(bundle_name, deploy_name, replace_output, update_only_resources,
               help='Preserve deploy output json file after resources removal')
 @verbose_option
 @timeit(action_name=CLEAN_ACTION)
-def clean(deploy_name, bundle_name, clean_only_types, clean_only_resources,
-          clean_only_resources_path, clean_externals, excluded_resources,
-          excluded_resources_path, excluded_types, preserve_state):
+def clean(
+        deploy_name: str,
+        bundle_name: str,
+        clean_only_types: tuple | None = None,
+        clean_only_resources: tuple | None = None,
+        clean_only_resources_path: str | None = None,
+        clean_externals: bool = False,
+        excluded_resources: tuple | None = None,
+        excluded_resources_path: str | None = None,
+        excluded_types: tuple | None = None,
+        preserve_state: bool = False,
+):
     """
     Cleans the application infrastructure
     """

--- a/syndicate/core/resources/lambda_resource.py
+++ b/syndicate/core/resources/lambda_resource.py
@@ -1208,6 +1208,7 @@ class LambdaResource(BaseResource):
     @retry()
     def _remove_lambda(self, arn, config):
         # can't describe lambda event sources with $LATEST version in arn
+        original_arn = arn
         arn = arn.replace(':$LATEST', '')
         lambda_name = config['resource_name']
         event_sources_meta = config['resource_meta'].get('event_sources', [])
@@ -1220,11 +1221,11 @@ class LambdaResource(BaseResource):
                 if lambda_name == each.split('/')[-1]:
                     self.cw_logs_conn.delete_log_group_name(each)
             _LOG.info('Lambda %s was removed.', lambda_name)
-            return {arn: config}
+            return {original_arn: config}
         except ClientError as e:
             if e.response['Error']['Code'] == 'ResourceNotFoundException':
                 _LOG.warn('Lambda %s is not found', lambda_name)
-                return {arn: config}
+                return {original_arn: config}
             else:
                 raise e
 


### PR DESCRIPTION
- Fix `clean` command for `output` folder to correctly resolve ARN for Lambda and properly process and remove the `outputs` folder if Lambda is part of the deployment
- Fix bucket name resolver to raise a user-friendly message if the bucket name does not match the specified regex
