### PR TITLE
Fix `clean` command for `output` folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ of each other or without specifying a specific platform (using default platform 
 - Fixed an issue related to locking the state
 - Added empty deployment package handling for lambda layer
 - Fixed bug when meta output processor process the resource name incorrectly
-- Fix bucket name resolver to raise a user-friendly message if the bucket name does not match the specified regex
+- Fix `clean` command for `output` folder to correctly resolve ARN for Lambda and properly process and remove the `outputs` folder if Lambda is part of the deployment
 
 # [1.14.1] - 2024-10-08
 - Added support lambda layers with runtime DotNet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ of each other or without specifying a specific platform (using default platform 
 - Fixed an issue related to locking the state
 - Added empty deployment package handling for lambda layer
 - Fixed bug when meta output processor process the resource name incorrectly
+- Fix bucket name resolver to raise a user-friendly message if the bucket name does not match the specified regex
 
 # [1.14.1] - 2024-10-08
 - Added support lambda layers with runtime DotNet

--- a/syndicate/core/resources/lambda_resource.py
+++ b/syndicate/core/resources/lambda_resource.py
@@ -1208,6 +1208,7 @@ class LambdaResource(BaseResource):
     @retry()
     def _remove_lambda(self, arn, config):
         # can't describe lambda event sources with $LATEST version in arn
+        original_arn = arn
         arn = arn.replace(':$LATEST', '')
         lambda_name = config['resource_name']
         event_sources_meta = config['resource_meta'].get('event_sources', [])
@@ -1220,11 +1221,11 @@ class LambdaResource(BaseResource):
                 if lambda_name == each.split('/')[-1]:
                     self.cw_logs_conn.delete_log_group_name(each)
             _LOG.info('Lambda %s was removed.', lambda_name)
-            return {arn: config}
+            return {original_arn: config}
         except ClientError as e:
             if e.response['Error']['Code'] == 'ResourceNotFoundException':
                 _LOG.warn('Lambda %s is not found', lambda_name)
-                return {arn: config}
+                return {original_arn: config}
             else:
                 raise e
 


### PR DESCRIPTION
Fix `clean` command for `output` folder to correctly resolve ARN for Lambda and properly process and remove the `outputs` folder if Lambda is part of the deployment
