### PR TITLE
Fix/modification lock priority lambda update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# [1.16.0] - 2024-12-13
+# [1.16.0] - 2024-12-17
 - Added support for the AppSync resource
 - Added the possibility to generate `s3_bucket` meta for static website hosting without public access
 - Added an example of lambda function URL configuration to the Python example 'lambda-basic'
+- Improved `modification_lock` resolving to avoid conflicts in case of work a few users with the same project
 - Update `zip_dir` to handle cases where the full path length exceeds 260 characters with a more informative error message
 - Ensure `zip_dir` validates the existence of the base directory before proceeding with the zipping process
 - Fix `tag_resources` and `untag_resources` to handle exceptions properly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved `modification_lock` resolving to avoid conflicts in case of work a few users with the same project
 - Update `zip_dir` to handle cases where the full path length exceeds 260 characters with a more informative error message
 - Ensure `zip_dir` validates the existence of the base directory before proceeding with the zipping process
+- Fixed duplication lambda function and lambda layer records in the output file after updating the resources
+- Fixed issue related to lambda function updating in case of changing lambda's alias name
 - Fix `tag_resources` and `untag_resources` to handle exceptions properly
 - Update `apply_tags`, `remove_tags`, and `update_tags` to return success status
 - Fix `clean` command for `output` folder to correctly resolve ARN for Lambda and properly process and remove the `outputs` folder if Lambda is part of the deployment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support tags for `OAS V3` as part of the `oas_v3.json` file, using the `x-syndicate-openapi-tags` key
 
 # [1.15.0] - 2024-10-28
-- Added new resource type `appsync`
 - Added `--skip_tests` option to `build`, `test` and `assemble_java_mvn` commands to not run tests during or after 
 building the bundle
 - Added `--errors_allowed` option to `assemble_python` and `assemble` commands

--- a/syndicate/connection/lambda_connection.py
+++ b/syndicate/connection/lambda_connection.py
@@ -271,7 +271,7 @@ class LambdaConnection(object):
 
         return self.client.create_alias(**params)
 
-    def get_alias(self, function_name, name):
+    def get_aliases(self, function_name: str, name: str = None) -> dict:
         all_aliases = {}
         next_marker = 1  # to enter the loop
         while next_marker:
@@ -288,6 +288,14 @@ class LambdaConnection(object):
             if all_aliases.get(name):
                 return all_aliases.get(name)
             next_marker = response.get('NextMarker')
+        return all_aliases
+
+    def delete_alias(self, function_name: str, name: str) -> None:
+        _LOG.debug(f'Removing lamba\'s \'{function_name}\' alias \'{name}\'')
+        self.client.delete_alias(
+            FunctionName=function_name,
+            Name=name
+        )
 
     def add_event_source(self, func_name, stream_arn, batch_size=10,
                          batch_window: Optional[int] = None,

--- a/syndicate/core/project_state/project_state.py
+++ b/syndicate/core/project_state/project_state.py
@@ -294,8 +294,8 @@ class ProjectState:
 
         return matches_operation and matches_bundle_name and status
 
-    def is_lock_free(self, lock_name):
-        lock = self.locks.get(lock_name)
+    def is_lock_free(self, lock_name=None, lock_config=None):
+        lock = lock_config or self.locks.get(lock_name)
         if not lock:
             return True
         elif not lock.get(LOCK_IS_LOCKED):
@@ -326,6 +326,9 @@ class ProjectState:
                 locks.update({lock_name: other_lock})
             elif other_lock is None:
                 other_locks.update({lock_name: lock})
+            elif (not self.is_lock_free(lock_config=other_lock) and
+                  getpass.getuser() != other_lock.get(LOCK_INITIATOR)):
+                locks.update({lock_name: other_lock})
             elif (lock.get(LOCK_LAST_MODIFICATION_DATE) <
                   other_lock.get(LOCK_LAST_MODIFICATION_DATE)):
                 locks.update({lock_name: other_lock})

--- a/tests/smoke/commons/connections.py
+++ b/tests/smoke/commons/connections.py
@@ -39,14 +39,6 @@ ACCOUNT_ID = sts_client.get_caller_identity()['Account']
 REGION = sts_client.meta.region_name
 
 
-def get_lambda_alias(function_name, alias_name):
-    try:
-        return lambda_client.get_alias(FunctionName=function_name,
-                                       Name=alias_name)
-    except lambda_client.exceptions.ResourceNotFoundException:
-        return None
-
-
 def get_s3_bucket_file_content(bucket_name, file_key):
     try:
         file_obj = s3_client.get_object(Bucket=bucket_name, Key=file_key)


### PR DESCRIPTION
- Improved `modification_lock` resolving to avoid conflicts in case of work a few users with the same project
- Fixed duplication lambda function and lambda layer records in the output file after updating the resources
- Fixed issue related to lambda function updating in case of changing lambda's alias name