### PR TITLE
Fix force upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [1.17.1] - 2025-03-07
+- Changed `--force_upload` parameter type for assemble commands from `string` to `flag`
+- Fixed logic of `--force_upload` flag in assemble commands
+
 # [1.17.0] - 2025-03-03
 - Added the possibility to generate meta for the resources `firehose` and `eventbridge_schedule`
 - The operation `partial_clean` added to the modification operations list

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # [1.17.1] - 2025-03-07
 - Changed `--force_upload` parameter type for assemble commands from `string` to `flag`
 - Fixed logic of `--force_upload` flag in assemble commands
+- Added `--force_upload` flag to `assemble_appsync` and `assemble_swagger_ui` commands
 
 # [1.17.0] - 2025-03-03
 - Added the possibility to generate meta for the resources `firehose` and `eventbridge_schedule`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed `--force_upload` parameter type for assemble commands from `string` to `flag`
 - Fixed logic of `--force_upload` flag in assemble commands
 - Added `--force_upload` flag to `assemble_appsync` and `assemble_swagger_ui` commands
+- Fixed issue if the last deploy output file was deleted from the s3 bucket, and it would result that lambda 
+triggers not being able to update
 
 # [1.17.0] - 2025-03-03
 - Added the possibility to generate meta for the resources `firehose` and `eventbridge_schedule`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# [1.17.1] - 2025-03-07
+# [1.17.1] - 2025-03-18
 - Changed `--force_upload` parameter type for assemble commands from `string` to `flag`
 - Fixed logic of `--force_upload` flag in assemble commands
 - Added `--force_upload` flag to `assemble_appsync` and `assemble_swagger_ui` commands

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='aws-syndicate',
-    version='1.17.0',
+    version='1.17.1',
     packages=find_packages(),
     include_package_data=True,
     install_requires=[

--- a/syndicate/core/build/artifact_processor.py
+++ b/syndicate/core/build/artifact_processor.py
@@ -54,7 +54,8 @@ _LOG = get_logger(__name__)
 
 
 def assemble_artifacts(bundle_name, project_path, runtime,
-                       errors_allowed=False, skip_tests=False, **kwargs):
+                       errors_allowed=False, skip_tests=False,
+                       force_upload=False, **kwargs):
     if runtime not in SUPPORTED_RUNTIMES:
         raise InvalidValueError(
             f"Runtime '{runtime}' is not supported. "
@@ -62,7 +63,11 @@ def assemble_artifacts(bundle_name, project_path, runtime,
 
     bundle_dir = resolve_bundle_directory(bundle_name=bundle_name)
 
-    os.makedirs(bundle_dir, exist_ok=True)
+    if force_upload:
+        os.makedirs(bundle_dir, exist_ok=True)
+    else:
+        os.makedirs(bundle_dir)
+
     _LOG.debug(f'Target directory: {bundle_dir}')
 
     assemble_func = RUNTIME_TO_BUILDER_MAPPING.get(runtime)

--- a/syndicate/core/build/artifact_processor.py
+++ b/syndicate/core/build/artifact_processor.py
@@ -54,8 +54,7 @@ _LOG = get_logger(__name__)
 
 
 def assemble_artifacts(bundle_name, project_path, runtime,
-                       errors_allowed=False, skip_tests=False,
-                       force_upload=False, **kwargs):
+                       errors_allowed=False, skip_tests=False, **kwargs):
     if runtime not in SUPPORTED_RUNTIMES:
         raise InvalidValueError(
             f"Runtime '{runtime}' is not supported. "
@@ -63,10 +62,7 @@ def assemble_artifacts(bundle_name, project_path, runtime,
 
     bundle_dir = resolve_bundle_directory(bundle_name=bundle_name)
 
-    if force_upload:
-        os.makedirs(bundle_dir, exist_ok=True)
-    else:
-        os.makedirs(bundle_dir)
+    os.makedirs(bundle_dir, exist_ok=True)
 
     _LOG.debug(f'Target directory: {bundle_dir}')
 

--- a/syndicate/core/build/bundle_processor.py
+++ b/syndicate/core/build/bundle_processor.py
@@ -221,6 +221,15 @@ def if_bundle_exist(bundle_name):
         key_compound)
 
 
+def if_bundle_exist_locally(bundle_name):
+    bundle_dir = resolve_bundle_directory(bundle_name=bundle_name)
+    normalized_bundle_dir = os.path.normpath(bundle_dir)
+    if os.path.exists(normalized_bundle_dir):
+        _LOG.debug(f'Bundle folder `{normalized_bundle_dir}` exists locally.')
+        return True
+    return False
+
+
 def upload_bundle_to_s3(bundle_name, force):
     if if_bundle_exist(bundle_name) and not force:
         raise ProjectStateError(

--- a/syndicate/core/build/validator/lambda_validator.py
+++ b/syndicate/core/build/validator/lambda_validator.py
@@ -139,8 +139,8 @@ class LambdaValidator:
 
         if errors:
             self._error(
-                f"Lambda '{self._name}' event sources haven't passed "
-                f"validation.\n{'\n'.join(errors)}")
+                f"Lambda '{0}' event sources haven't passed "
+                f"validation.\n{1}".format(self._name, '\n'.join(errors)))
 
 
 def validate_lambda(name, meta):

--- a/syndicate/core/handlers.py
+++ b/syndicate/core/handlers.py
@@ -31,7 +31,7 @@ from syndicate.core.build.artifact_processor import RUNTIME_NODEJS, \
     RUNTIME_DOTNET, RUNTIME_APPSYNC
 from syndicate.core.build.bundle_processor import create_bundles_bucket, \
     load_bundle, upload_bundle_to_s3, if_bundle_exist, \
-    remove_bundle_dir_locally
+    remove_bundle_dir_locally, if_bundle_exist_locally
 from syndicate.core.build.deployment_processor import \
     create_deployment_resources, remove_deployment_resources, \
     update_deployment_resources
@@ -776,6 +776,10 @@ def assemble_python(bundle_name, project_path, force_upload, errors_allowed,
     :return:
     """
     USER_LOG.info(f'Command assemble python: project_path: {project_path} ')
+
+    if if_bundle_exist_locally(bundle_name) and not force_upload:
+        raise FileExistsError(f'Cannot assemble bundle {bundle_name} - folder '
+                              f'with such name exists in the bundle folder.')
     if force_upload:
         _LOG.info(f'Force upload is enabled, going to check if bundle '
                   f'directory already exists locally.')
@@ -823,6 +827,10 @@ def assemble_node(bundle_name, project_path, force_upload,
     :return:
     """
     USER_LOG.info(f'Command assemble node: project_path: {project_path} ')
+
+    if if_bundle_exist_locally(bundle_name) and not force_upload:
+        raise FileExistsError(f'Cannot assemble bundle {bundle_name} - folder '
+                              f'with such name exists in the bundle folder.')
     if force_upload:
         _LOG.info(f'Force upload is enabled, going to check if bundle '
                   f'directory already exists locally.')
@@ -869,6 +877,10 @@ def assemble_dotnet(bundle_name, project_path, force_upload,
     :return:
     """
     USER_LOG.info(f'Command assemble dotnet: project_path: {project_path} ')
+
+    if if_bundle_exist_locally(bundle_name) and not force_upload:
+        raise FileExistsError(f'Cannot assemble bundle {bundle_name} - folder '
+                              f'with such name exists in the bundle folder.')
     if force_upload:
         _LOG.info(f'Force upload is enabled, going to check if bundle '
                   f'directory already exists locally.')
@@ -912,6 +924,9 @@ def assemble_swagger_ui(**kwargs):
     USER_LOG.info(f'Command assemble Swagger UI: project_path: {project_path} ')
 
     force_upload = kwargs.get('force_upload')
+    if if_bundle_exist_locally(bundle_name) and not force_upload:
+        raise FileExistsError(f'Cannot assemble bundle {bundle_name} - folder '
+                              f'with such name exists in the bundle folder.')
     if force_upload:
         _LOG.info(f'Force upload is enabled, going to check if bundle '
                   f'directory already exists locally.')
@@ -955,6 +970,10 @@ def assemble_appsync(**kwargs):
     USER_LOG.info(f'Command assemble AppSync: project_path: {project_path} ')
 
     force_upload = kwargs.get('force_upload')
+
+    if if_bundle_exist_locally(bundle_name) and not force_upload:
+        raise FileExistsError(f'Cannot assemble bundle {bundle_name} - folder '
+                              f'with such name exists in the bundle folder.')
     if force_upload:
         _LOG.info(f'Force upload is enabled, going to check if bundle '
                   f'directory already exists locally.')
@@ -1005,6 +1024,9 @@ def assemble(ctx, bundle_name, force_upload, errors_allowed, skip_tests=False):
     :param skip_tests: allows to skip tests
     :return:
     """
+    if if_bundle_exist_locally(bundle_name) and not force_upload:
+        raise FileExistsError(f'Cannot assemble bundle {bundle_name} - folder '
+                              f'with such name exists in the bundle folder.')
     if force_upload:
         _LOG.info(f'Force upload is enabled, going to check if bundle '
                   f'directory already exists locally.')

--- a/syndicate/core/handlers.py
+++ b/syndicate/core/handlers.py
@@ -76,6 +76,7 @@ from syndicate.core.constants import TEST_ACTION, BUILD_ACTION, \
     COPY_BUNDLE_ACTION, EXPORT_ACTION, ASSEMBLE_SWAGGER_UI_ACTION, \
     ASSEMBLE_DOTNET_ACTION, ASSEMBLE_APPSYNC_ACTION, OK_RETURN_CODE, \
     FAILED_RETURN_CODE, ABORTED_RETURN_CODE
+from syndicate.exceptions import ProjectStateError
 
 INIT_COMMAND_NAME = 'init'
 SYNDICATE_PACKAGE_NAME = 'aws-syndicate'
@@ -724,6 +725,12 @@ def assemble_java_mvn(bundle_name, project_path, force_upload, skip_tests,
     :return:
     """
     USER_LOG.info(f'Command compile java project path: {project_path}')
+
+    if if_bundle_exist_locally(bundle_name) and not force_upload:
+        raise ProjectStateError(
+            f'Bundle name \'{bundle_name}\' already exists locally. Please '
+            f'use another bundle name or delete the existing'
+        )
     if force_upload:
         _LOG.info(f'Force upload is enabled, going to check if bundle '
                   f'directory already exists locally.')
@@ -778,8 +785,10 @@ def assemble_python(bundle_name, project_path, force_upload, errors_allowed,
     USER_LOG.info(f'Command assemble python: project_path: {project_path} ')
 
     if if_bundle_exist_locally(bundle_name) and not force_upload:
-        raise FileExistsError(f'Cannot assemble bundle {bundle_name} - folder '
-                              f'with such name exists in the bundle folder.')
+        raise ProjectStateError(
+            f'Bundle name \'{bundle_name}\' already exists locally. Please '
+            f'use another bundle name or delete the existing'
+        )
     if force_upload:
         _LOG.info(f'Force upload is enabled, going to check if bundle '
                   f'directory already exists locally.')
@@ -829,8 +838,10 @@ def assemble_node(bundle_name, project_path, force_upload,
     USER_LOG.info(f'Command assemble node: project_path: {project_path} ')
 
     if if_bundle_exist_locally(bundle_name) and not force_upload:
-        raise FileExistsError(f'Cannot assemble bundle {bundle_name} - folder '
-                              f'with such name exists in the bundle folder.')
+        raise ProjectStateError(
+            f'Bundle name \'{bundle_name}\' already exists locally. Please '
+            f'use another bundle name or delete the existing'
+        )
     if force_upload:
         _LOG.info(f'Force upload is enabled, going to check if bundle '
                   f'directory already exists locally.')
@@ -879,8 +890,10 @@ def assemble_dotnet(bundle_name, project_path, force_upload,
     USER_LOG.info(f'Command assemble dotnet: project_path: {project_path} ')
 
     if if_bundle_exist_locally(bundle_name) and not force_upload:
-        raise FileExistsError(f'Cannot assemble bundle {bundle_name} - folder '
-                              f'with such name exists in the bundle folder.')
+        raise ProjectStateError(
+            f'Bundle name \'{bundle_name}\' already exists locally. Please '
+            f'use another bundle name or delete the existing'
+        )
     if force_upload:
         _LOG.info(f'Force upload is enabled, going to check if bundle '
                   f'directory already exists locally.')
@@ -925,8 +938,10 @@ def assemble_swagger_ui(**kwargs):
 
     force_upload = kwargs.get('force_upload')
     if if_bundle_exist_locally(bundle_name) and not force_upload:
-        raise FileExistsError(f'Cannot assemble bundle {bundle_name} - folder '
-                              f'with such name exists in the bundle folder.')
+        raise ProjectStateError(
+            f'Bundle name \'{bundle_name}\' already exists locally. Please '
+            f'use another bundle name or delete the existing'
+        )
     if force_upload:
         _LOG.info(f'Force upload is enabled, going to check if bundle '
                   f'directory already exists locally.')
@@ -972,8 +987,10 @@ def assemble_appsync(**kwargs):
     force_upload = kwargs.get('force_upload')
 
     if if_bundle_exist_locally(bundle_name) and not force_upload:
-        raise FileExistsError(f'Cannot assemble bundle {bundle_name} - folder '
-                              f'with such name exists in the bundle folder.')
+        raise ProjectStateError(
+            f'Bundle name \'{bundle_name}\' already exists locally. Please '
+            f'use another bundle name or delete the existing'
+        )
     if force_upload:
         _LOG.info(f'Force upload is enabled, going to check if bundle '
                   f'directory already exists locally.')
@@ -1025,8 +1042,10 @@ def assemble(ctx, bundle_name, force_upload, errors_allowed, skip_tests=False):
     :return:
     """
     if if_bundle_exist_locally(bundle_name) and not force_upload:
-        raise FileExistsError(f'Cannot assemble bundle {bundle_name} - folder '
-                              f'with such name exists in the bundle folder.')
+        raise ProjectStateError(
+            f'Bundle name \'{bundle_name}\' already exists locally. Please '
+            f'use another bundle name or delete the existing'
+        )
     if force_upload:
         _LOG.info(f'Force upload is enabled, going to check if bundle '
                   f'directory already exists locally.')

--- a/syndicate/core/handlers.py
+++ b/syndicate/core/handlers.py
@@ -688,11 +688,9 @@ def profiler(bundle_name, deploy_name, from_date, to_date):
                    'path for an mvn clean install. The artifacts are copied '
                    'to a folder, which is be later used as the deployment '
                    'bundle (the bundle path: bundles/${bundle_name})')
-@click.option('--force_upload', '-fu', nargs=1,
-              default=False, required=False,
-              help='Identifier that indicates whether a locally existing'
-                   ' bundle should be deleted and a new one created using'
-                   ' the same path.')
+@click.option('--force_upload', '-F', is_flag=True, default=False,
+              help='Flag to override locally existing bundle '
+                   'with the same name')
 @click.option('--skip_tests', is_flag=True, default=False,
               help='Flag to not run tests')
 @click.option('--errors_allowed', is_flag=True, default=False,
@@ -744,11 +742,9 @@ def assemble_java_mvn(bundle_name, project_path, force_upload, skip_tests,
                    'found, which are described in the requirements.txt file, '
                    'and internal project dependencies according to the '
                    'described in local_requirements.txt file')
-@click.option('--force_upload', '-fu', nargs=1,
-              default=False, required=False,
-              help='Identifier that indicates whether a locally existing'
-                   ' bundle should be deleted and a new one created using'
-                   ' the same path.')
+@click.option('--force_upload', '-F', is_flag=True, default=False,
+              help='Flag to override locally existing bundle '
+                   'with the same name')
 @click.option('--errors_allowed', is_flag=True, default=False,
               help='Flag to continue building the bundle if any errors occur '
                    'while building dependencies')
@@ -778,7 +774,8 @@ def assemble_python(bundle_name, project_path, force_upload, errors_allowed,
     assemble_artifacts(bundle_name=bundle_name,
                        project_path=project_path,
                        runtime=RUNTIME_PYTHON,
-                       errors_allowed=errors_allowed)
+                       errors_allowed=errors_allowed,
+                       force_upload=force_upload)
     USER_LOG.info('Python artifacts were prepared successfully.')
     return OK_RETURN_CODE
 
@@ -795,11 +792,9 @@ def assemble_python(bundle_name, project_path, force_upload, errors_allowed,
               help='The path to the NodeJS project. The code is '
                    'packed to a zip archive, where the external libraries are '
                    'found, which are described in the package.json file')
-@click.option('--force_upload', '-fu', nargs=1,
-              default=False, required=False,
-              help='Identifier that indicates whether a locally existing'
-                   ' bundle should be deleted and a new one created using'
-                   ' the same path.')
+@click.option('--force_upload', '-F', is_flag=True, default=False,
+              help='Flag to override locally existing bundle '
+                   'with the same name')
 @verbose_option
 @timeit(action_name=ASSEMBLE_NODE_ACTION)
 @failed_status_code_on_exception
@@ -843,11 +838,9 @@ def assemble_node(bundle_name, project_path, force_upload,
               help='The path to the NodeJS project. The code is '
                    'packed to a zip archive, where the external libraries are '
                    'found, which are described in the package.json file')
-@click.option('--force_upload', '-fu', nargs=1,
-              default=False, required=False,
-              help='Identifier that indicates whether a locally existing'
-                   ' bundle should be deleted and a new one created using'
-                   ' the same path.')
+@click.option('--force_upload', '-F', is_flag=True, default=False,
+              help='Flag to override locally existing bundle '
+                   'with the same name')
 @verbose_option
 @timeit(action_name=ASSEMBLE_DOTNET_ACTION)
 @failed_status_code_on_exception
@@ -960,11 +953,9 @@ RUNTIME_LANG_TO_BUILD_MAPPING = {
 @click.option('--bundle_name', '-b', callback=generate_default_bundle_name,
               help='Bundle\'s name to build the lambdas in. '
                    'Default value: $ProjectName_%Y%m%d.%H%M%S')
-@click.option('--force_upload', '-fu', nargs=1,
-              default=False, required=False,
-              help='Identifier that indicates whether a locally existing'
-                   ' bundle should be deleted and a new one created using'
-                   ' the same path.')
+@click.option('--force_upload', '-F', is_flag=True, default=False,
+              help='Flag to override locally existing bundle '
+                   'with the same name')
 @click.option('--errors_allowed', is_flag=True, default=False,
               help='Flag to continue building the bundle if any errors occur '
                    'while building dependencies. Only for Python runtime.')

--- a/syndicate/core/handlers.py
+++ b/syndicate/core/handlers.py
@@ -733,8 +733,7 @@ def assemble_java_mvn(bundle_name, project_path, force_upload, skip_tests,
                        project_path=project_path,
                        runtime=RUNTIME_JAVA,
                        skip_tests=skip_tests,
-                       errors_allowed=errors_allowed,
-                       force_upload=force_upload)
+                       errors_allowed=errors_allowed)
     USER_LOG.info('Java artifacts were prepared successfully.')
     return OK_RETURN_CODE
 
@@ -785,8 +784,7 @@ def assemble_python(bundle_name, project_path, force_upload, errors_allowed,
     assemble_artifacts(bundle_name=bundle_name,
                        project_path=project_path,
                        runtime=RUNTIME_PYTHON,
-                       errors_allowed=errors_allowed,
-                       force_upload=force_upload)
+                       errors_allowed=errors_allowed)
     USER_LOG.info('Python artifacts were prepared successfully.')
     return OK_RETURN_CODE
 
@@ -832,8 +830,7 @@ def assemble_node(bundle_name, project_path, force_upload,
 
     assemble_artifacts(bundle_name=bundle_name,
                        project_path=project_path,
-                       runtime=RUNTIME_NODEJS,
-                       force_upload=force_upload)
+                       runtime=RUNTIME_NODEJS)
     USER_LOG.info('NodeJS artifacts were prepared successfully.')
     return OK_RETURN_CODE
 
@@ -879,8 +876,7 @@ def assemble_dotnet(bundle_name, project_path, force_upload,
 
     assemble_artifacts(bundle_name=bundle_name,
                        project_path=project_path,
-                       runtime=RUNTIME_DOTNET,
-                       force_upload=force_upload)
+                       runtime=RUNTIME_DOTNET)
     USER_LOG.info('DotNet artifacts were prepared successfully.')
     return OK_RETURN_CODE
 
@@ -923,8 +919,7 @@ def assemble_swagger_ui(**kwargs):
 
     assemble_artifacts(bundle_name=bundle_name,
                        project_path=project_path,
-                       runtime=RUNTIME_SWAGGER_UI,
-                       force_upload=force_upload)
+                       runtime=RUNTIME_SWAGGER_UI)
     USER_LOG.info('Swagger UI artifacts were prepared successfully.')
     return OK_RETURN_CODE
 
@@ -967,8 +962,7 @@ def assemble_appsync(**kwargs):
 
     assemble_artifacts(bundle_name=bundle_name,
                        project_path=project_path,
-                       runtime=RUNTIME_APPSYNC,
-                       force_upload=force_upload)
+                       runtime=RUNTIME_APPSYNC)
     USER_LOG.info('AppSync artifacts were prepared successfully.')
     return OK_RETURN_CODE
 

--- a/syndicate/core/handlers.py
+++ b/syndicate/core/handlers.py
@@ -733,7 +733,8 @@ def assemble_java_mvn(bundle_name, project_path, force_upload, skip_tests,
                        project_path=project_path,
                        runtime=RUNTIME_JAVA,
                        skip_tests=skip_tests,
-                       errors_allowed=errors_allowed)
+                       errors_allowed=errors_allowed,
+                       force_upload=force_upload)
     USER_LOG.info('Java artifacts were prepared successfully.')
     return OK_RETURN_CODE
 
@@ -831,7 +832,8 @@ def assemble_node(bundle_name, project_path, force_upload,
 
     assemble_artifacts(bundle_name=bundle_name,
                        project_path=project_path,
-                       runtime=RUNTIME_NODEJS)
+                       runtime=RUNTIME_NODEJS,
+                       force_upload=force_upload)
     USER_LOG.info('NodeJS artifacts were prepared successfully.')
     return OK_RETURN_CODE
 
@@ -877,7 +879,8 @@ def assemble_dotnet(bundle_name, project_path, force_upload,
 
     assemble_artifacts(bundle_name=bundle_name,
                        project_path=project_path,
-                       runtime=RUNTIME_DOTNET)
+                       runtime=RUNTIME_DOTNET,
+                       force_upload=force_upload)
     USER_LOG.info('DotNet artifacts were prepared successfully.')
     return OK_RETURN_CODE
 
@@ -893,6 +896,9 @@ def assemble_dotnet(bundle_name, project_path, force_upload,
               callback=resolve_path_callback, required=True,
               help='The path to the project. Related files will be packed '
                    'into a zip archive.')
+@click.option('--force_upload', '-F', is_flag=True, default=False,
+              help='Flag to override locally existing bundle '
+                   'with the same name')
 @verbose_option
 @timeit(action_name=ASSEMBLE_SWAGGER_UI_ACTION)
 @failed_status_code_on_exception
@@ -908,9 +914,17 @@ def assemble_swagger_ui(**kwargs):
     bundle_name = kwargs.get('bundle_name')
     project_path = kwargs.get('project_path')
     USER_LOG.info(f'Command assemble Swagger UI: project_path: {project_path} ')
+
+    force_upload = kwargs.get('force_upload')
+    if force_upload:
+        _LOG.info(f'Force upload is enabled, going to check if bundle '
+                  f'directory already exists locally.')
+        remove_bundle_dir_locally(bundle_name)
+
     assemble_artifacts(bundle_name=bundle_name,
                        project_path=project_path,
-                       runtime=RUNTIME_SWAGGER_UI)
+                       runtime=RUNTIME_SWAGGER_UI,
+                       force_upload=force_upload)
     USER_LOG.info('Swagger UI artifacts were prepared successfully.')
     return OK_RETURN_CODE
 
@@ -926,6 +940,9 @@ def assemble_swagger_ui(**kwargs):
               callback=resolve_path_callback, required=True,
               help='The path to the project. Related files will be packed '
                    'into a zip archive.')
+@click.option('--force_upload', '-F', is_flag=True, default=False,
+              help='Flag to override locally existing bundle '
+                   'with the same name')
 @verbose_option
 @timeit(action_name=ASSEMBLE_APPSYNC_ACTION)
 @failed_status_code_on_exception
@@ -941,9 +958,17 @@ def assemble_appsync(**kwargs):
     bundle_name = kwargs.get('bundle_name')
     project_path = kwargs.get('project_path')
     USER_LOG.info(f'Command assemble AppSync: project_path: {project_path} ')
+
+    force_upload = kwargs.get('force_upload')
+    if force_upload:
+        _LOG.info(f'Force upload is enabled, going to check if bundle '
+                  f'directory already exists locally.')
+        remove_bundle_dir_locally(bundle_name)
+
     assemble_artifacts(bundle_name=bundle_name,
                        project_path=project_path,
-                       runtime=RUNTIME_APPSYNC)
+                       runtime=RUNTIME_APPSYNC,
+                       force_upload=force_upload)
     USER_LOG.info('AppSync artifacts were prepared successfully.')
     return OK_RETURN_CODE
 

--- a/syndicate/core/resources/lambda_resource.py
+++ b/syndicate/core/resources/lambda_resource.py
@@ -1202,9 +1202,15 @@ class LambdaResource(BaseResource):
                 _build_output_key(
                     bundle_name=bundle_name, deploy_name=deploy_name,
                     is_regular_output=False)).as_posix()
-
-        output_file = self.s3_conn.load_file_body(
-            CONFIG.deploy_target_bucket, key_compound)
+        try:
+            output_file = self.s3_conn.load_file_body(
+                CONFIG.deploy_target_bucket, key_compound)
+        except self.s3_conn.exceptions.NoSuchKey:
+            _LOG.warning(
+                f'Cannot find deployment output {key_compound} in the bucket '
+                f'{CONFIG.deploy_target_bucket}. Cannot process {name} '
+                f'lambda triggers from previous deploy.')
+            output_file = '{}'
         latest_output = json.loads(output_file)
 
         prev_event_sources_meta = []


### PR DESCRIPTION
- Changed `--force_upload` parameter type for assemble commands from `string` to `flag`
- Fixed logic of `--force_upload` flag in assemble commands
- Added `--force_upload` flag to `assemble_appsync` and `assemble_swagger_ui` commands
- Fixed issue if the last deploy output file was deleted from the s3 bucket, and it would result that lambda 
triggers not being able to update