### PR TITLE
Simplify autotests configuration + Dynamic aliases

### DIFF
--- a/tests/CHANGELOG.md
+++ b/tests/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2025-05-20
+### Added
+- Added ability to specify alias in lambda env dictionary in such format: '${alias_name}'. Can be combined with wildcard
+### Changed
+- Removed prefix, suffix and deploy_target_bucket from `init_parameters` as required parameters. 
+Instead, they will be extracted from syndicate.yml config
+
 ## 2025-03-14
 ### Added
 - Added prefixes to test project configurations and information about their usage to the readme file.

--- a/tests/smoke/commons/checkers.py
+++ b/tests/smoke/commons/checkers.py
@@ -212,7 +212,7 @@ def lambda_envs_checker(lambda_name: str, envs: dict,
                 if alias_value:
                     value = value[:start - 2] + str(alias_value) + value[end + 1:]
 
-                if lambda_envs[key] == alias_value:
+                if lambda_envs[key] == value:
                     lambda_envs.pop(key)
                     continue
                 if '*' in value:

--- a/tests/smoke/commons/step_processors.py
+++ b/tests/smoke/commons/step_processors.py
@@ -18,7 +18,7 @@ from commons.utils import UpdateContent
 
 
 def process_steps(steps: dict[str: List[dict]],
-                  verbose: Optional[bool] = False,skip_stage: bool = False,
+                  verbose: Optional[bool] = False, skip_stage: bool = False,
                   **kwargs):
     result = []
     for step in steps[STEPS_CONFIG_PARAM]:

--- a/tests/smoke/commons/utils.py
+++ b/tests/smoke/commons/utils.py
@@ -1,8 +1,9 @@
+import functools
 import json
 import os
+
 import yaml
 from functools import reduce
-from pathlib import Path
 from typing import Union, Any, Optional
 
 from commons.constants import UPDATE_COMMAND
@@ -219,6 +220,7 @@ def split_deploy_bucket_path(deploy_target_bucket: str) -> tuple[str, list]:
     return deploy_target_bucket, []
 
 
+@functools.cache
 def read_syndicate_aliases() -> Optional[dict]:
     conf_path = os.environ.get('SDCT_CONF')
     if not conf_path:

--- a/tests/smoke/configs/ddis_resources_check_config.json
+++ b/tests/smoke/configs/ddis_resources_check_config.json
@@ -1,8 +1,5 @@
 {
   "init_parameters": {
-    "suffix": "",
-    "deploy_target_bucket": "",
-    "prefix": "ddis-",
     "output_file": "output"
   },
   "stages": {
@@ -918,9 +915,9 @@
                 "sdct-at-nodejs-lambda": {
                   "cup_client_id": "*",
                   "cup_id": "*",
-                  "reservations_table": "*sdct-at-reservation*",
-                  "tables_table": "*sdct-at-table*",
-                  "region": "eu-central-1"
+                  "reservations_table": "*${reservations_table}*",
+                  "tables_table": "*${tables_table}*",
+                  "region": "${region}"
                 }
               },
               "depends_on": [1, 4]

--- a/tests/smoke/configs/ddis_resources_check_config.json
+++ b/tests/smoke/configs/ddis_resources_check_config.json
@@ -1063,10 +1063,10 @@
               "description": "Check if lambda environment variables were updated",
               "env_variables": {
                 "sdct-at-nodejs-lambda": {
-                  "new_region": "eu-central-1",
-                  "region": "updated_eu-central-1",
-                  "tables_table": "*sdct-at-table*",
-                  "reservations_table": "*sdct-at-reservation*",
+                  "new_region": "${region}",
+                  "region": "updated_${region}",
+                  "reservations_table": "*${reservations_table}*",
+                  "tables_table": "*${tables_table}*",
                   "cup_client_id": "*",
                   "cup_id": "*"
                 }

--- a/tests/smoke/configs/least_used_resources_check_config.json
+++ b/tests/smoke/configs/least_used_resources_check_config.json
@@ -1,8 +1,5 @@
 {
   "init_parameters": {
-    "suffix": "",
-    "deploy_target_bucket": "",
-    "prefix": "lur-",
     "output_file": "least_used_output"
   },
   "stages": {

--- a/tests/smoke/entry_point.py
+++ b/tests/smoke/entry_point.py
@@ -36,7 +36,10 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def force_clean(deploy_bucket, only_bundle=False):
+def force_clean(only_bundle=False):
+    from syndicate.core.conf.processor import ConfigHolder
+    from syndicate.core import CONF_PATH
+
     print(f'\nCleaning bundle {"and resources" if not only_bundle else ""}')
     if not only_bundle:
         command_to_execute = ['syndicate', 'clean']
@@ -44,7 +47,8 @@ def force_clean(deploy_bucket, only_bundle=False):
                                      capture_output=True, text=True)
         print(f'Execution return code: {exec_result.returncode}')
 
-    deploy_bucket, path = split_deploy_bucket_path(deploy_bucket)
+    config = ConfigHolder(CONF_PATH)
+    deploy_bucket, path = split_deploy_bucket_path(config.deploy_target_bucket)
     delete_s3_folder(deploy_bucket, os.path.join(*path, BUNDLE_NAME))
     delete_s3_folder(deploy_bucket, os.path.join(*path, UPDATED_BUNDLE_NAME))
 
@@ -91,7 +95,7 @@ def main(verbose: bool, config: str):
                 i['stage_passed'] for i in result[STAGES_CONFIG_PARAM][CLEAN_COMMAND]):
             print('Only bundle is True')
             only_bundle = True
-        force_clean(init_params.get('deploy_target_bucket'), only_bundle)
+        force_clean(only_bundle)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Added
- Added ability to specify alias in lambda env dictionary in such format: '${alias_name}'. Can be combined with wildcard
### Changed
- Removed prefix, suffix and deploy_target_bucket from `init_parameters` as required parameters. 
Instead, they will be extracted from syndicate.yml config