### PR TITLE
snapstart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# [1.18.1] - 2025-08-08
+# [1.18.1] - 2025-08-13
 - Added warning message in case the resource that was specified using parameter `-resources` is not found in the build meta during the `syndicate deploy/update/clean` command execution
 - Add `tracing_mode` parameter to the list of supported parameters to update
+- Added support of `snapstart` parameter in lambda resource for python 3.12+ and .NET 8+ runtimes
 
 # [1.18.0] - 2025-08-01
 - Added support for DynamoDB `OnDemandThroughput` limitation

--- a/syndicate/core/resources/lambda_resource.py
+++ b/syndicate/core/resources/lambda_resource.py
@@ -1450,10 +1450,17 @@ class LambdaResource(BaseResource):
         if not snap_start:
             return None
 
+        if not isinstance(snap_start, str):
+            raise ParameterError(
+                f'Invalid SnapStart value in "{SNAP_START}". '
+                f'Expected a string, but got {type(snap_start).__name__}.'
+            )
+
         if snap_start.lower() not in _SNAP_START_CONFIGURATIONS:
             raise ParameterError(
                 f'Invalid SnapStart value in "{SNAP_START}". '
-                f'Must be one of: published_versions, PublishedVersions, NONE.'
+                f'Expected one of these: published_versions, '
+                f'PublishedVersions, NONE. But got "{snap_start}".'
             )
 
         if not self.snap_start_supported_runtime(runtime):


### PR DESCRIPTION
Added support of `snapstart` parameter in lambda resource for python 3.12+ and .NET 8+ runtimes