### PR TITLE
.syndicate inconsistence + type validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# [1.18.1] - 2025-08-13
+# [1.18.1] - 2025-08-19
 - Added warning message in case the resource that was specified using parameter `-resources` is not found in the build meta during the `syndicate deploy/update/clean` command execution
 - Add `tracing_mode` parameter to the list of supported parameters to update
 - Added support of `snapstart` parameter in lambda resource for python 3.12+ and .NET 8+ runtimes
+- Added validation of incoming resource type for `deploy`, `update`, and `clean` commands
+- Moved `.syndicate` file location from project path to config path to avoid merging project states for different 
+configurations within a single project
 
 # [1.18.0] - 2025-08-01
 - Added support for DynamoDB `OnDemandThroughput` limitation

--- a/syndicate/core/__init__.py
+++ b/syndicate/core/__init__.py
@@ -188,18 +188,19 @@ def initialize_connection():
 def initialize_project_state(do_not_sync_state=False):
     from syndicate.core.project_state.sync_processor import sync_project_state
     global PROJECT_STATE
-    if not ProjectState.check_if_project_state_exists(CONFIG.project_path):
-        USER_LOG.warning(
-            "Config is set and generated, but project state file does not "
-            "exist."
-        )
-        USER_LOG.warning(
-            "Generating project state file '.syndicate' from the existing "
-            "structure..."
-        )
-        PROJECT_STATE = ProjectState.build_from_structure(CONFIG)
-    else:
-        PROJECT_STATE = ProjectState(project_path=CONFIG.project_path)
+    if not PROJECT_STATE:
+        if not ProjectState.check_if_project_state_exists(CONF_PATH):
+            USER_LOG.warning(
+                "Config is set and generated, but project state file does not "
+                "exist."
+            )
+            USER_LOG.warning(
+                "Generating project state file '.syndicate' from the existing "
+                "structure..."
+            )
+            PROJECT_STATE = ProjectState.build_from_structure(CONFIG)
+        else:
+            PROJECT_STATE = ProjectState(project_path=CONFIG.project_path)
 
     if do_not_sync_state:
         return

--- a/syndicate/core/build/deployment_processor.py
+++ b/syndicate/core/build/deployment_processor.py
@@ -643,10 +643,9 @@ def update_deployment_resources(
     _LOG.debug('Artifacts s3 paths were resolved')
     resolve_tags(resources)
 
-    USER_LOG.warning(
-        'Please pay attention that only the '
-        'following resources types are supported for update: {}'.format(
-            list(PROCESSOR_FACADE.update_handlers().keys())))
+    USER_LOG.warning(f'Please pay attention that only the following resources '
+                     f'types are supported for update: '
+                     f'{UPDATE_RESOURCE_TYPE_PRIORITY.keys()}')
 
     update_only_resources = _resolve_names(update_only_resources)
     _LOG.info(

--- a/syndicate/core/generators/appsync.py
+++ b/syndicate/core/generators/appsync.py
@@ -17,7 +17,7 @@ import sys
 from pathlib import Path, PurePath
 
 from syndicate.commons.log_helper import get_logger, get_user_logger
-from syndicate.core import ProjectState
+from syndicate.core import ProjectState, CONF_PATH
 from syndicate.core.constants import APPSYNC_SCHEMA_DEFAULT_FILE_NAME, \
     APPSYNC_CONFIG_FILE_NAME
 from syndicate.core.generators import _mkdir, _touch, _write_content_to_file
@@ -41,8 +41,7 @@ def generate_appsync(name, project_path, tags):
         USER_LOG.info(f'Project "{project_path}" you '
                       f'have provided does not exist')
         return
-    if not ProjectState.check_if_project_state_exists(
-            project_path=project_path):
+    if not ProjectState.check_if_project_state_exists(project_path=CONF_PATH):
         USER_LOG.info(f'Seems that the path {project_path} is not a project')
         return
 

--- a/syndicate/core/generators/lambda_function.py
+++ b/syndicate/core/generators/lambda_function.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 from syndicate.exceptions import InvalidValueError
 from syndicate.commons.log_helper import get_logger, get_user_logger
-from syndicate.core import ProjectState
+from syndicate.core import ProjectState, CONF_PATH
 from syndicate.core.project_state.project_state import BUILD_MAPPINGS
 from syndicate.core.generators import (_touch,
                                        _mkdir, _write_content_to_file,
@@ -140,8 +140,7 @@ def generate_lambda_function(project_path, runtime, lambda_names, tags):
                       f'have provided does not exist')
         return
 
-    if not ProjectState.check_if_project_state_exists(
-            project_path=project_path):
+    if not ProjectState.check_if_project_state_exists(project_path=CONF_PATH):
         USER_LOG.info(f'Seems that the path {project_path} is not a project')
         return
     project_state = ProjectState(project_path=project_path)
@@ -186,8 +185,7 @@ def generate_lambda_layer(name, runtime, project_path, lambda_names=None):
                       f'have provided does not exist')
         return
 
-    if not ProjectState.check_if_project_state_exists(
-            project_path=project_path):
+    if not ProjectState.check_if_project_state_exists(project_path=CONF_PATH):
         USER_LOG.info(f'Seems that the path {project_path} is not a project')
         return
     project_state = ProjectState(project_path=project_path)

--- a/syndicate/core/generators/project.py
+++ b/syndicate/core/generators/project.py
@@ -67,8 +67,7 @@ def generate_project_structure(project_name, project_path):
         _write_content_to_file(file=os.path.join(full_project_path,
                                                  FILE_DEPLOYMENT_RESOURCES),
                                content=default_lambda_policy)
-        ProjectState.generate(project_name=project_name,
-                              project_path=full_project_path)
+        ProjectState.generate(project_name=project_name)
 
         _write_content_to_file(os.path.join(full_project_path, FILE_CHANGELOG),
                                CHANGELOG_TEMPLATE)

--- a/syndicate/core/generators/swagger_ui.py
+++ b/syndicate/core/generators/swagger_ui.py
@@ -19,7 +19,7 @@ from pathlib import Path, PurePath
 
 from syndicate.exceptions import InvalidValueError
 from syndicate.commons.log_helper import get_logger, get_user_logger
-from syndicate.core import ProjectState
+from syndicate.core import ProjectState, CONF_PATH
 from syndicate.core.constants import SWAGGER_UI_SPEC_NAME_TEMPLATE, \
     SWAGGER_UI_CONFIG_FILE_NAME
 from syndicate.core.generators import _mkdir, _touch, _write_content_to_file
@@ -42,7 +42,7 @@ def generate_swagger_ui(name, spec_path, target_bucket, project_path):
                       f'have provided does not exist')
         return
     if not ProjectState.check_if_project_state_exists(
-            project_path=project_path):
+            project_path=CONF_PATH):
         USER_LOG.info(f'Seems that the path {project_path} is not a project')
         return
     if not Path.is_absolute(abs_path_to_spec):

--- a/syndicate/core/handlers.py
+++ b/syndicate/core/handlers.py
@@ -78,8 +78,9 @@ from syndicate.core.constants import TEST_ACTION, BUILD_ACTION, \
     PACKAGE_META_ACTION, CREATE_DEPLOY_TARGET_BUCKET_ACTION, UPLOAD_ACTION, \
     COPY_BUNDLE_ACTION, EXPORT_ACTION, ASSEMBLE_SWAGGER_UI_ACTION, \
     ASSEMBLE_DOTNET_ACTION, ASSEMBLE_APPSYNC_ACTION, OK_RETURN_CODE, \
-    FAILED_RETURN_CODE, ABORTED_RETURN_CODE, \
-    UNDERSCORE_CREATE_DEPLOY_TARGET_BUCKET_ACTION
+    FAILED_RETURN_CODE, ABORTED_RETURN_CODE, UPDATE_RESOURCE_TYPE_PRIORITY, \
+    UNDERSCORE_CREATE_DEPLOY_TARGET_BUCKET_ACTION, \
+    DEPLOY_RESOURCE_TYPE_PRIORITY, CLEAN_RESOURCE_TYPE_PRIORITY
 from syndicate.exceptions import ProjectStateError
 
 INIT_COMMAND_NAME = 'init'
@@ -297,6 +298,7 @@ def transform(bundle_name, dsl, output_dir):
                    'Default value: name of the latest built bundle')
 @click.option('--deploy-only-types', '-types',
               cls=MultiWordOption, multiple=True,
+              type=click.Choice(DEPLOY_RESOURCE_TYPE_PRIORITY),
               help='Types of the resources to deploy')
 @click.option('--deploy-only-resources', '-resources',
               cls=MultiWordOption, multiple=True,
@@ -313,6 +315,7 @@ def transform(bundle_name, dsl, output_dir):
                    'while deploy')
 @click.option('--excluded-types', '-extypes',
               cls=MultiWordOption, multiple=True,
+              type=click.Choice(DEPLOY_RESOURCE_TYPE_PRIORITY),
               help='Types of the resources to skip while deploy')
 @click.option('--continue-deploy',
               cls=MultiWordOption, is_flag=True, default=False,
@@ -405,6 +408,7 @@ def deploy(
               help='Name of the deploy. Default value: name of the project')
 @click.option('--update-only-types', '-types',
               cls=MultiWordOption, multiple=True,
+              type=click.Choice(UPDATE_RESOURCE_TYPE_PRIORITY),
               help='Types of the resources to update')
 @click.option('--update-only-resources',
               '-resources', cls=MultiWordOption, multiple=True,
@@ -422,6 +426,7 @@ def deploy(
                    'while update')
 @click.option('--excluded-types', '-extypes',
               cls=MultiWordOption, multiple=True,
+              type=click.Choice(UPDATE_RESOURCE_TYPE_PRIORITY),
               help='Types of the resources to skip while update')
 @click.option('--replace-output', nargs=1,
               cls=MultiWordOption, is_flag=True, default=False,
@@ -496,6 +501,7 @@ def update(
 @failed_status_code_on_exception
 @click.option('--clean-only-types', '-types',
               cls=MultiWordOption, multiple=True,
+              type=click.Choice(CLEAN_RESOURCE_TYPE_PRIORITY),
               help='If specified only provided types will be cleaned')
 @click.option('--clean-only-resources', '-resources',
               cls=MultiWordOption, multiple=True,
@@ -515,6 +521,7 @@ def update(
               help='If specified provided resource path will be excluded')
 @click.option('--excluded-types', '-extypes',
               cls=MultiWordOption, multiple=True,
+              type=click.Choice(CLEAN_RESOURCE_TYPE_PRIORITY),
               help='If specified provided types will be excluded')
 @click.option('--preserve-state',
               cls=MultiWordOption, is_flag=True,

--- a/syndicate/core/project_state/project_state.py
+++ b/syndicate/core/project_state/project_state.py
@@ -77,24 +77,28 @@ class ProjectState:
         _dict variable instead of loading from a file. It comes handy when
         we need to get ProjectState object without loading from file. All
         the existing functionality remains unimpaired"""
+        from syndicate.core import CONF_PATH
+
         if not (project_path or dct):
             raise InternalError(
                 "Either 'project_path' or 'dct' of both must be specified!"
             )
         if project_path:
             self.project_path = project_path
-            self.state_path = os.path.join(project_path, PROJECT_STATE_FILE)
+            self.state_path = os.path.join(CONF_PATH, PROJECT_STATE_FILE)
         self.dct = dct if dct else self.__load_project_state_file()
         self._current_deploy = None
         self._current_bundle = None
 
     @staticmethod
-    def generate(project_path, project_name):
+    def generate(project_name):
+        from syndicate.core import CONF_PATH
+
         project_state = dict(name=project_name)
-        with open(os.path.join(project_path, PROJECT_STATE_FILE),
+        with open(os.path.join(CONF_PATH, PROJECT_STATE_FILE),
                   'w') as state_file:
             yaml.dump(project_state, state_file)
-        return ProjectState(project_path=project_path)
+        return ProjectState(project_path=CONF_PATH)
 
     @staticmethod
     def check_if_project_state_exists(project_path):
@@ -549,9 +553,11 @@ class ProjectState:
         self.save()
 
     def __load_project_state_file(self):
-        if not ProjectState.check_if_project_state_exists(self.project_path):
+        from syndicate.core import CONF_PATH
+
+        if not ProjectState.check_if_project_state_exists(CONF_PATH):
             raise ProjectStateError(
-                f"There is no '.syndicate' file in '{self.project_path}'"
+                f"There is no '.syndicate' file in '{CONF_PATH}'"
             )
         with open(self.state_path) as state_file:
             return yaml.safe_load(state_file.read())
@@ -583,8 +589,7 @@ class ProjectState:
             resolve_lambda_path
         absolute_path = config.project_path
         project_path = Path(absolute_path)
-        project_state = ProjectState.generate(project_path=absolute_path,
-                                              project_name=project_path.name)
+        project_state = ProjectState.generate(project_name=project_path.name)
 
         for runtime, source_path in BUILD_MAPPINGS.items():
             lambdas_path = resolve_lambda_path(project_path, runtime,


### PR DESCRIPTION
- Added validation of incoming resource type for `deploy`, `update`, and `clean` commands
- Moved `.syndicate` file location from project path to config path to avoid merging project states for different 
configurations within a single project