### PR TITLE
Fix/resources names warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [1.18.2] - 2025-08-29
+- Fixed an issue related to updating DynamoDB tables
+- Fixed an issue related to removing lambda layers from the output file after cleaning them
+
 # [1.18.1] - 2025-08-20
 - Added warning message in case the resource that was specified using parameter `-resources` is not found in the build meta during the `syndicate deploy/update/clean` command execution
 - Add `tracing_mode` parameter to the list of supported parameters to update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # [1.18.2] - 2025-08-29
 - Fixed an issue related to updating DynamoDB tables
 - Fixed an issue related to removing lambda layers from the output file after cleaning them
+- Fixed an issue that leads to the permanent warning in case of filtering resources by name during the `deploy`, `update`, and `clean` commands
+- Added information message with resource names to be processed to the user console log in case of filtering resources during the `deploy`, `update`, and `clean` commands
+- Added abortion of the `deploy`, `update`, and `clean` commands in case no resources to process after filtering
 
 # [1.18.1] - 2025-08-20
 - Added warning message in case the resource that was specified using parameter `-resources` is not found in the build meta during the `syndicate deploy/update/clean` command execution

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["setuptools"]
 
 [project]
 name = "aws-syndicate"
-version = "1.18.1"
+version = "1.18.2"
 description = "AWS-syndicate is an Amazon Web Services deployment framework written in Python, which allows to easily deploy serverless applications using resource descriptions."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/syndicate/core/handlers.py
+++ b/syndicate/core/handlers.py
@@ -384,6 +384,10 @@ def deploy(
         rollback_on_error=rollback_on_error,
     )
 
+    if deploy_success == ABORTED_STATUS:
+        USER_LOG.warning('Deployment of resources has been aborted')
+        return ABORTED_RETURN_CODE
+
     message = 'Backend resources were deployed{suffix}.'.format(
         suffix='' if deploy_success else (
             ' with errors. Rollback is enabled, resources from this '
@@ -497,8 +501,8 @@ def update(
         USER_LOG.info('Update of resources has been successfully completed')
         return OK_RETURN_CODE
     elif success == ABORTED_STATUS:
-        # not ABORTED_RETURN_CODE because of event status in .syndicate file
-        return FAILED_RETURN_CODE
+        USER_LOG.info('Update of resources has been aborted')
+        return ABORTED_RETURN_CODE
     else:
         USER_LOG.warning('Something went wrong during resources update')
         return FAILED_RETURN_CODE

--- a/syndicate/core/helper.py
+++ b/syndicate/core/helper.py
@@ -1080,3 +1080,14 @@ def are_resource_types_valid(param_name: str,
         )
         return False
     return True
+
+def strip_prefix_suffix(res_name: str) -> str:
+    """
+    Strips the resource prefix and suffix if it is present.
+    """
+    from syndicate.core import CONFIG
+    if CONFIG.resources_prefix and res_name.startswith(CONFIG.resources_prefix):
+        res_name = res_name[len(CONFIG.resources_prefix):]
+    if CONFIG.resources_suffix and res_name.endswith(CONFIG.resources_suffix):
+        res_name = res_name[:-len(CONFIG.resources_suffix)]
+    return res_name

--- a/syndicate/core/resources/dynamo_db_resource.py
+++ b/syndicate/core/resources/dynamo_db_resource.py
@@ -110,11 +110,6 @@ class DynamoDBResource(AbstractExternalResource, BaseResource):
             )
             provisioned_throughput = dict()
 
-        warm_throughput = dict(
-            ReadUnitsPerSecond=table.warm_throughput.get('ReadUnitsPerSecond'),
-            WriteUnitsPerSecond=table.warm_throughput.get('WriteUnitsPerSecond')
-        )
-
         if billing_mode != existing_billing_mode:
             USER_LOG.info(
                 f"Updating the table '{name}'. It may take up to 20 minutes, "
@@ -125,12 +120,9 @@ class DynamoDBResource(AbstractExternalResource, BaseResource):
             billing_mode=billing_mode,
             read_capacity=meta.get('read_capacity'),
             write_capacity=meta.get('write_capacity'),
-            warm_read_capacity=meta.get('warm_read_capacity'),
-            warm_write_capacity=meta.get('warm_write_capacity'),
             existing_billing_mode=existing_billing_mode,
             existing_provisioned_throughput=provisioned_throughput,
             existing_on_demand_throughput=on_demand_throughput,
-            existing_warm_throughput=warm_throughput,
             existing_global_indexes=table.global_secondary_indexes or []
         )
         if response:
@@ -153,10 +145,6 @@ class DynamoDBResource(AbstractExternalResource, BaseResource):
             existing_global_indexes=table.global_secondary_indexes or [],
             table_read_capacity=table_read_capacity,
             table_write_capacity=table_write_capacity,
-            table_warm_read_capacity=
-                table.warm_throughput.get('ReadUnitsPerSecond'),
-            table_warm_write_capacity=
-                table.warm_throughput.get('WriteUnitsPerSecond'),
             existing_capacity_mode=existing_billing_mode
         )
 
@@ -283,8 +271,6 @@ class DynamoDBResource(AbstractExternalResource, BaseResource):
             meta.get('billing_mode', 'PROVISIONED'),
             meta.get('sort_key_name'), meta.get('sort_key_type'),
             meta.get('read_capacity'), meta.get('write_capacity'),
-            warm_read_capacity=meta.get('warm_read_capacity'),
-            warm_write_capacity=meta.get('warm_write_capacity'),
             global_indexes=meta.get('global_indexes'),
             local_indexes=meta.get('local_indexes'),
             tags=meta.get('tags'),

--- a/syndicate/core/resources/lambda_resource.py
+++ b/syndicate/core/resources/lambda_resource.py
@@ -1403,9 +1403,9 @@ class LambdaResource(BaseResource):
         layers_list = self.lambda_conn.list_lambda_layer_versions(layer_name)
 
         try:
-            for arn in [layer['LayerVersionArn'] for layer in layers_list]:
-                layer_version = arn.split(':')[-1]
-                self.lambda_conn.delete_layer(arn, log_not_found_error=False)
+            for l_arn in [layer['LayerVersionArn'] for layer in layers_list]:
+                layer_version = l_arn.split(':')[-1]
+                self.lambda_conn.delete_layer(l_arn, log_not_found_error=False)
                 _LOG.info('Lambda layer {0} version {1} was removed.'.format(
                     layer_name, layer_version))
             return {arn: config}

--- a/tests/CHANGELOG.md
+++ b/tests/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2025-08-29
+- Fixed an issue with building python lambda layer
+- Fixed `NoSuchBucket` error during checking the existence of a Swagger UI in case the bucket does not exist
+
 ## 2025-05-06
 ### Added
 - Added ability to specify alias in lambda env dictionary in such format: '${alias_name}'. Can be combined with wildcard

--- a/tests/smoke/commons/checkers.py
+++ b/tests/smoke/commons/checkers.py
@@ -10,7 +10,7 @@ sys.path.append(parent_dir)
 
 from commons.constants import BUNDLE_NAME, DEPLOY_NAME, \
     RESOURCE_TYPE_CONFIG_PARAM, RESOURCE_NAME_CONFIG_PARAM, \
-    RESOURCE_META_CONFIG_PARAM, UPDATED_BUNDLE_NAME
+    RESOURCE_META_CONFIG_PARAM
 from commons.utils import deep_get, find_max_lambda_layer_version, \
     compare_dicts, read_syndicate_aliases
 from commons import connections

--- a/tests/smoke/commons/connections.py
+++ b/tests/smoke/commons/connections.py
@@ -57,6 +57,9 @@ def get_s3_bucket_file_content(bucket_name, file_key):
 def get_s3_bucket_object(bucket_name, file_key):
     try:
         file_obj = s3_client.get_object(Bucket=bucket_name, Key=file_key)
+    except s3_client.exceptions.NoSuchBucket:
+        print(f'Not found bucket {bucket_name}')
+        return
     except s3_client.exceptions.NoSuchKey:
         print(f'Not found key {file_key} in the bucket {bucket_name}')
         return

--- a/tests/smoke/commons/constants.py
+++ b/tests/smoke/commons/constants.py
@@ -1,10 +1,6 @@
-from datetime import datetime
 
 DEPLOY_NAME = 'autotest'
 BUNDLE_NAME = 'happy_path_autotest'
-UPDATED_BUNDLE_NAME = 'happy_path_autotest_updated_{time}'.format(
-    time=datetime.now().isoformat().replace(':', '_')
-)
 
 BUILD_COMMAND = 'build'
 DEPLOY_COMMAND = 'deploy'

--- a/tests/smoke/commons/handlers.py
+++ b/tests/smoke/commons/handlers.py
@@ -17,8 +17,7 @@ from commons import connections
 from commons.constants import DEPLOY_OUTPUT_DIR, RESOURCE_TYPE_CONFIG_PARAM, \
     BUNDLE_NAME, DEPLOY_NAME, SWAGGER_UI_RESOURCE_TYPE, TAGS_CONFIG_PARAM, \
     API_GATEWAY_OAS_V3_RESOURCE_TYPE, LAMBDA_LAYER_RESOURCE_TYPE, \
-    RESOURCE_NAME_CONFIG_PARAM, UPDATED_BUNDLE_NAME, \
-    RDS_DB_INSTANCE_RESOURCE_TYPE
+    RESOURCE_NAME_CONFIG_PARAM, RDS_DB_INSTANCE_RESOURCE_TYPE
 from syndicate.core.conf.processor import ConfigHolder
 from syndicate.core import CONF_PATH
 
@@ -35,18 +34,16 @@ def exit_code_handler(actual_exit_code: int, expected_exit_code: int,
 def artifacts_existence_handler(artifacts_list: list,
                                 reverse_check: bool = False,
                                 succeeded_deploy: Optional[bool] = None,
-                                update: Optional[bool] = None,
                                 **kwargs):
     deploy_bucket, path = split_deploy_bucket_path(CONFIG.deploy_target_bucket)
-    bundle_dir = UPDATED_BUNDLE_NAME if update else BUNDLE_NAME
     missing_resources = []
     for artifact in artifacts_list:
         if succeeded_deploy is not None:
             file_key = '/'.join([
-                *path, bundle_dir, DEPLOY_OUTPUT_DIR, artifact
+                *path, BUNDLE_NAME, DEPLOY_OUTPUT_DIR, artifact
             ])
         else:
-            file_key = '/'.join([*path, bundle_dir, artifact])
+            file_key = '/'.join([*path, BUNDLE_NAME, artifact])
         is_file_exists = artifacts_existence_checker(file_key,
                                                      deploy_bucket)
         if is_file_exists and reverse_check:
@@ -87,10 +84,9 @@ def build_meta_content_handler(resources: dict, **kwargs):
 def deployment_output_handler(resources: dict,
                               succeeded_deploy: bool = True,
                               reverse_check: bool = False,
-                              update: Optional[bool] = False, **kwargs):
+                              **kwargs):
     deploy_bucket, path = split_deploy_bucket_path(CONFIG.deploy_target_bucket)
-    bundle_dir = UPDATED_BUNDLE_NAME if update else BUNDLE_NAME
-    output_path = '/'.join([*path, bundle_dir, DEPLOY_OUTPUT_DIR, DEPLOY_NAME])
+    output_path = '/'.join([*path, BUNDLE_NAME, DEPLOY_OUTPUT_DIR, DEPLOY_NAME])
     if succeeded_deploy:
         output_path += '.json'
     else:

--- a/tests/smoke/commons/step_processors.py
+++ b/tests/smoke/commons/step_processors.py
@@ -8,7 +8,7 @@ from pathlib import Path
 parent_dir = str(Path(__file__).resolve().parent.parent)
 sys.path.append(parent_dir)
 
-from commons.constants import STEPS_CONFIG_PARAM, UPDATED_BUNDLE_NAME, \
+from commons.constants import STEPS_CONFIG_PARAM, \
     COMMAND_CONFIG_PARAM, CHECKS_CONFIG_PARAM, NAME_CONFIG_PARAM, \
     DESCRIPTION_CONFIG_PARAM, DEPENDS_ON_CONFIG_PARAM, BUILD_COMMAND, \
     BUNDLE_NAME, DEPLOY_COMMAND, UPDATE_COMMAND, DEPLOY_NAME, \
@@ -46,7 +46,8 @@ def process_steps(steps: dict[str: List[dict]],
                                        '--deploy-name', DEPLOY_NAME,
                                        '--replace-output'])
         if UPDATE_COMMAND in command_to_execute:
-            command_to_execute.extend(['--bundle-name', UPDATED_BUNDLE_NAME,
+            command_to_execute.extend(['--bundle-name', BUNDLE_NAME,
+                                       '--deploy-name', DEPLOY_NAME,
                                        '--replace-output'])
         execution_datetime = datetime.utcnow()
 
@@ -57,8 +58,8 @@ def process_steps(steps: dict[str: List[dict]],
                 appsync_path=[os.path.join('appsync_src',
                                            'sdct-at-appsync')]):
             if UPDATE_COMMAND in command_to_execute:
-                build_command = ['syndicate', 'build',
-                                 '--bundle_name', UPDATED_BUNDLE_NAME]
+                build_command = ['syndicate', 'build', '--bundle_name',
+                                 BUNDLE_NAME, '--force-upload']
                 if verbose:
                     build_command.append('--verbose')
                 print(f'Run command: {build_command}')

--- a/tests/smoke/configs/ddis_aurora_resources_check_config.json
+++ b/tests/smoke/configs/ddis_aurora_resources_check_config.json
@@ -1,0 +1,401 @@
+{
+  "init_parameters": {
+    "output_file": "ddis_aurora_output"
+  },
+  "stages": {
+    "build": {
+      "steps": [
+        {
+          "description": "Build bundle",
+          "command": [
+            "syndicate",
+            "build"
+          ],
+          "checks": [
+            {
+              "index": 1,
+              "name": "exit_code",
+              "description": "Check if actual status code equals expected",
+              "expected_exit_code": 0
+            },
+            {
+              "index": 2,
+              "name": "artifacts_existence",
+              "description": "Check if artifacts exist",
+              "artifacts_list": [
+                "build_meta.json",
+                "sdct-at-ddis-aurora-1.0.0.jar"
+              ],
+              "depends_on": [
+                1
+              ]
+            },
+            {
+              "index": 3,
+              "name": "build_meta",
+              "description": "Check if all resources exist in build meta",
+              "resources": {
+                "sdct-at-lambda-basic-execution-policy": {
+                  "resource_type": "iam_policy"
+                },
+                "sdct-at-java-lambda-role": {
+                  "resource_type": "iam_role"
+                },
+                "sdct-at-java-lambda": {
+                  "resource_type": "lambda"
+                },
+                "sdct-at-rds-db-cluster": {
+                  "resource_type": "rds_db_cluster"
+                },
+                "sdct-at-rds-db-instance": {
+                  "resource_type": "rds_db_instance"
+                }
+              },
+              "depends_on": [
+                1
+              ]
+            },
+            {
+              "index": 4,
+              "name": "build_meta_content",
+              "description": "Check if all resources in build meta contain required meta",
+              "resources": {
+                "sdct-at-lambda-basic-execution-policy": {
+                  "resource_type": "iam_policy",
+                  "tags": {
+                    "tests": "smoke",
+                    "project": "sdct-auto-test",
+                    "project-level-tag": "set-from-resource"
+                  }
+                },
+                "sdct-at-java-lambda-role": {
+                  "resource_type": "iam_role",
+                  "tags": {
+                    "tests": "smoke",
+                    "project": "sdct-auto-test"
+                  }
+                },
+                "sdct-at-java-lambda": {
+                  "resource_type": "lambda",
+                  "tags": {
+                    "tests": "smoke",
+                    "project": "sdct-auto-test"
+                  },
+                  "env_variables": {
+                    "MASTER_CREDENTIALS_SECRET_NAME": {
+                      "resource_type": "rds_db_cluster",
+                      "parameter": "master_user_secret_name",
+                      "resource_name": "sdct-at-rds-db-cluster"
+                    },
+                    "ENDPOINT": {
+                      "resource_type": "rds_db_cluster",
+                      "parameter": "endpoint",
+                      "resource_name": "sdct-at-rds-db-cluster"
+                    }
+                  }
+                },
+                "sdct-at-rds-db-cluster": {
+                  "resource_type": "rds_db_cluster",
+                  "tags": {
+                    "tests": "smoke",
+                    "project": "sdct-auto-test"
+                  }
+                },
+                "sdct-at-rds-db-instance": {
+                  "resource_type": "rds_db_instance",
+                  "tags": {
+                    "tests": "smoke",
+                    "project": "sdct-auto-test"
+                  }
+                }
+              },
+              "depends_on": [
+                1
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "deploy": {
+      "steps": [
+        {
+          "description": "Deployment without dependencies",
+          "command": [
+            "syndicate",
+            "deploy"
+          ],
+          "checks": [
+            {
+              "index": 1,
+              "name": "exit_code",
+              "description": "Check if actual status code equals expected",
+              "expected_exit_code": 0
+            },
+            {
+              "index": 2,
+              "name": "artifacts_existence",
+              "description": "Check if succeeded deployment output file exists in S3 bucket",
+              "succeeded_deploy": true,
+              "artifacts_list": [
+                "autotest.json"
+              ],
+              "depends_on": [
+                1
+              ]
+            },
+            {
+              "index": 3,
+              "name": "deployment_output",
+              "description": "Check if all resources present in deployment output",
+              "succeeded_deploy": true,
+              "resources": {
+                "sdct-at-lambda-basic-execution-policy": {
+                  "resource_type": "iam_policy"
+                },
+                "sdct-at-java-lambda-role": {
+                  "resource_type": "iam_role"
+                },
+                "sdct-at-java-lambda": {
+                  "resource_type": "lambda"
+                },
+                "sdct-at-rds-db-cluster": {
+                  "resource_type": "rds_db_cluster"
+                },
+                "sdct-at-rds-db-instance": {
+                  "resource_type": "rds_db_instance"
+                }
+              },
+              "depends_on": [
+                1,
+                2
+              ]
+            },
+            {
+              "index": 4,
+              "name": "resource_existence",
+              "description": "Check if all resources present in account",
+              "resources": {
+                "sdct-at-lambda-basic-execution-policy": {
+                  "resource_type": "iam_policy"
+                },
+                "sdct-at-java-lambda-role": {
+                  "resource_type": "iam_role"
+                },
+                "sdct-at-java-lambda": {
+                  "resource_type": "lambda"
+                },
+                "sdct-at-rds-db-cluster": {
+                  "resource_type": "rds_db_cluster"
+                },
+                "sdct-at-rds-db-instance": {
+                  "resource_type": "rds_db_instance"
+                }
+              },
+              "depends_on": [
+                1,
+                2,
+                3
+              ]
+            },
+            {
+              "index": 5,
+              "name": "tag_existence",
+              "description": "Check if tags is present",
+              "resources": {
+                "sdct-at-rds-db-cluster": {
+                  "resource_type": "rds_db_cluster",
+                  "tags": {
+                    "tests": "smoke",
+                    "project": "sdct-auto-test",
+                    "project-level-tag": "set-from-project"
+                  }
+                },
+                "sdct-at-rds-db-instance": {
+                  "resource_type": "rds_db_instance",
+                  "tags": {
+                    "tests": "smoke",
+                    "project": "sdct-auto-test",
+                    "project-level-tag": "set-from-project"
+                  }
+                }
+              },
+              "depends_on": [
+                1,
+                2
+              ]
+            }
+          ]
+        }
+      ],
+      "depends_on": [
+        "build"
+      ]
+    },
+    "update": {
+      "steps": [
+        {
+          "description": "Updating resources",
+          "command": [
+            "syndicate",
+            "update",
+            "--force"
+          ],
+          "checks": [
+            {
+              "index": 1,
+              "name": "exit_code",
+              "description": "Check if actual status code equals expected",
+              "expected_exit_code": 0
+            },
+            {
+              "index": 2,
+              "name": "artifacts_existence",
+              "description": "Check if succeeded deployment output file exists in S3 bucket",
+              "succeeded_deploy": true,
+              "artifacts_list": [
+                "autotest.json"
+              ],
+              "depends_on": [
+                1
+              ]
+            },
+            {
+              "index": 3,
+              "name": "deployment_output",
+              "description": "Check if all resources present in deployment output",
+              "succeeded_deploy": true,
+              "resources": {
+                "sdct-at-lambda-basic-execution-policy": {
+                  "resource_type": "iam_policy"
+                },
+                "sdct-at-java-lambda-role": {
+                  "resource_type": "iam_role"
+                },
+                "sdct-at-java-lambda": {
+                  "resource_type": "lambda"
+                },
+                "sdct-at-rds-db-cluster": {
+                  "resource_type": "rds_db_cluster"
+                },
+                "sdct-at-rds-db-instance": {
+                  "resource_type": "rds_db_instance"
+                }
+              },
+              "depends_on": [
+                1
+              ]
+            },
+            {
+              "index": 4,
+              "name": "lambda_env_existence",
+              "description": "Check if lambda environment variables were updated",
+              "env_variables": {
+                "sdct-at-java-lambda": {
+                  "ENDPOINT": "*${region}.rds.amazonaws.com",
+                  "MASTER_CREDENTIALS_SECRET_NAME": "rds!cluster*"
+                }
+              },
+              "depends_on": [
+                1,
+                2
+              ]
+            },
+            {
+              "index": 5,
+              "name": "tag_existence",
+              "description": "Check if tags is present",
+              "resources": {
+                "sdct-at-rds-db-cluster": {
+                  "resource_type": "rds_db_cluster",
+                  "tags": {
+                    "tests": "smoke",
+                    "project": "sdct-auto-test",
+                    "project-level-tag": "set-from-project"
+                  }
+                },
+                "sdct-at-rds-db-instance": {
+                  "resource_type": "rds_db_instance",
+                  "tags": {
+                    "tests": "smoke",
+                    "project": "sdct-auto-test",
+                    "project-level-tag": "set-from-project"
+                  }
+                }
+              },
+              "depends_on": [
+                1,
+                2
+              ]
+            }
+          ]
+        }
+      ],
+      "depends_on": [
+        "deploy"
+      ]
+    },
+    "clean": {
+      "steps": [
+        {
+          "description": "Clean all resources",
+          "command": [
+            "syndicate",
+            "clean"
+          ],
+          "checks": [
+            {
+              "index": 1,
+              "name": "exit_code",
+              "description": "Check if actual status code equals expected",
+              "expected_exit_code": 0
+            },
+            {
+              "index": 2,
+              "name": "artifacts_existence",
+              "description": "Check if succeeded deployment output file does not exist in S3 bucket",
+              "succeeded_deploy": true,
+              "reverse_check": true,
+              "artifacts_list": [
+                "autotest.json"
+              ],
+              "depends_on": [
+                1
+              ]
+            },
+            {
+              "index": 3,
+              "name": "resource_existence",
+              "reverse_check": true,
+              "description": "Check if all resources are not present in account",
+              "resources": {
+                "sdct-at-lambda-basic-execution-policy": {
+                  "resource_type": "iam_policy"
+                },
+                "sdct-at-java-lambda-role": {
+                  "resource_type": "iam_role"
+                },
+                "sdct-at-java-lambda": {
+                  "resource_type": "lambda"
+                },
+                "sdct-at-rds-db-cluster": {
+                  "resource_type": "rds_db_cluster"
+                },
+                "sdct-at-rds-db-instance": {
+                  "resource_type": "rds_db_instance"
+                }
+              },
+              "depends_on": [
+                1
+              ]
+            }
+          ]
+        }
+      ],
+      "depends_on": [
+        "build",
+        "deploy"
+      ]
+    }
+  }
+}

--- a/tests/smoke/configs/ddis_resources_check_config.json
+++ b/tests/smoke/configs/ddis_resources_check_config.json
@@ -1,6 +1,6 @@
 {
   "init_parameters": {
-    "output_file": "output"
+    "output_file": "ddis_output"
   },
   "stages": {
     "build": {
@@ -118,12 +118,6 @@
                 },
                 "sdct-at-open-api-gw": {
                   "resource_type": "api_gateway_oas_v3"
-                },
-                "sdct-at-rds-db-cluster": {
-                  "resource_type": "rds_db_cluster"
-                },
-                "sdct-at-rds-db-instance": {
-                  "resource_type": "rds_db_instance"
                 }
               },
               "depends_on": [
@@ -162,18 +156,6 @@
                   "tags": {
                     "tests": "smoke",
                     "project": "sdct-auto-test"
-                  },
-                  "env_variables": {
-                    "MASTER_CREDENTIALS_SECRET_NAME": {
-                      "resource_type": "rds_db_cluster",
-                      "parameter": "master_user_secret_name",
-                      "resource_name": "sdct-at-rds-db-cluster"
-                    },
-                    "ENDPOINT": {
-                      "resource_type": "rds_db_cluster",
-                      "parameter": "endpoint",
-                      "resource_name": "sdct-at-rds-db-cluster"
-                    }
                   }
                 },
                 "sdct-at-java-lambda_layer": {
@@ -312,20 +294,6 @@
                 },
                 "sdct-at-open-api-gw": {
                   "resource_type": "api_gateway_oas_v3"
-                },
-                "sdct-at-rds-db-cluster": {
-                  "resource_type": "rds_db_cluster",
-                  "tags": {
-                    "tests": "smoke",
-                    "project": "sdct-auto-test"
-                  }
-                },
-                "sdct-at-rds-db-instance": {
-                  "resource_type": "rds_db_instance",
-                  "tags": {
-                    "tests": "smoke",
-                    "project": "sdct-auto-test"
-                  }
                 }
               },
               "depends_on": [
@@ -437,12 +405,6 @@
                 },
                 "sdct-at-appsync": {
                   "resource_type": "appsync"
-                },
-                "sdct-at-rds-db-cluster": {
-                  "resource_type": "rds_db_cluster"
-                },
-                "sdct-at-rds-db-instance": {
-                  "resource_type": "rds_db_instance"
                 }
               },
               "depends_on": [
@@ -542,12 +504,6 @@
                 },
                 "sdct-at-appsync": {
                   "resource_type": "appsync"
-                },
-                "sdct-at-rds-db-cluster": {
-                  "resource_type": "rds_db_cluster"
-                },
-                "sdct-at-rds-db-instance": {
-                  "resource_type": "rds_db_instance"
                 }
               },
               "depends_on": [
@@ -704,12 +660,6 @@
                 },
                 "sdct-at-appsync": {
                   "resource_type": "appsync"
-                },
-                "sdct-at-rds-db-cluster": {
-                  "resource_type": "rds_db_cluster"
-                },
-                "sdct-at-rds-db-instance": {
-                  "resource_type": "rds_db_instance"
                 }
               }
             },
@@ -792,12 +742,6 @@
                 },
                 "sdct-at-appsync": {
                   "resource_type": "appsync"
-                },
-                "sdct-at-rds-db-cluster": {
-                  "resource_type": "rds_db_cluster"
-                },
-                "sdct-at-rds-db-instance": {
-                  "resource_type": "rds_db_instance"
                 }
               }
             },
@@ -942,22 +886,6 @@
                     "project": "sdct-auto-test",
                     "project-level-tag": "set-from-project"
                   }
-                },
-                "sdct-at-rds-db-cluster": {
-                  "resource_type": "rds_db_cluster",
-                  "tags": {
-                    "tests": "smoke",
-                    "project": "sdct-auto-test",
-                    "project-level-tag": "set-from-project"
-                  }
-                },
-                "sdct-at-rds-db-instance": {
-                  "resource_type": "rds_db_instance",
-                  "tags": {
-                    "tests": "smoke",
-                    "project": "sdct-auto-test",
-                    "project-level-tag": "set-from-project"
-                  }
                 }
               },
               "depends_on": [
@@ -1041,10 +969,6 @@
                   "reservations_table": "*${reservations_table}*",
                   "tables_table": "*${tables_table}*",
                   "region": "${region}"
-                },
-                "sdct-at-java-lambda": {
-                  "ENDPOINT": "*${region}.rds.amazonaws.com",
-                  "MASTER_CREDENTIALS_SECRET_NAME": "rds!cluster*"
                 }
               },
               "depends_on": [
@@ -1080,7 +1004,6 @@
               "name": "artifacts_existence",
               "description": "Check if succeeded deployment output file exists in S3 bucket",
               "succeeded_deploy": true,
-              "update": true,
               "artifacts_list": [
                 "autotest.json"
               ],
@@ -1168,12 +1091,6 @@
                 },
                 "sdct-at-appsync": {
                   "resource_type": "appsync"
-                },
-                "sdct-at-rds-db-cluster": {
-                  "resource_type": "rds_db_cluster"
-                },
-                "sdct-at-rds-db-instance": {
-                  "resource_type": "rds_db_instance"
                 }
               },
               "depends_on": [
@@ -1257,10 +1174,6 @@
                   "tables_table": "*${tables_table}*",
                   "cup_client_id": "*",
                   "cup_id": "*"
-                },
-                "sdct-at-java-lambda": {
-                  "ENDPOINT": "*${region}.rds.amazonaws.com",
-                  "MASTER_CREDENTIALS_SECRET_NAME": "rds!cluster*"
                 }
               },
               "depends_on": [
@@ -1427,12 +1340,6 @@
                 },
                 "sdct-at-appsync": {
                   "resource_type": "appsync"
-                },
-                "sdct-at-rds-db-cluster": {
-                  "resource_type": "rds_db_cluster"
-                },
-                "sdct-at-rds-db-instance": {
-                  "resource_type": "rds_db_instance"
                 }
               },
               "depends_on": [
@@ -1532,12 +1439,6 @@
                 },
                 "sdct-at-appsync": {
                   "resource_type": "appsync"
-                },
-                "sdct-at-rds-db-cluster": {
-                  "resource_type": "rds_db_cluster"
-                },
-                "sdct-at-rds-db-instance": {
-                  "resource_type": "rds_db_instance"
                 }
               },
               "depends_on": [
@@ -1594,7 +1495,7 @@
             {
               "index": 2,
               "name": "artifacts_existence",
-              "description": "Check if succeeded deployment output file exists in S3 bucket",
+              "description": "Check if succeeded deployment output file does not exist in S3 bucket",
               "succeeded_deploy": true,
               "reverse_check": true,
               "artifacts_list": [
@@ -1684,12 +1585,6 @@
                 },
                 "sdct-at-appsync": {
                   "resource_type": "appsync"
-                },
-                "sdct-at-rds-db-cluster": {
-                  "resource_type": "rds_db_cluster"
-                },
-                "sdct-at-rds-db-instance": {
-                  "resource_type": "rds_db_instance"
                 }
               },
               "depends_on": [

--- a/tests/smoke/entry_point.py
+++ b/tests/smoke/entry_point.py
@@ -12,7 +12,7 @@ sys.path.append(parent_dir)
 from commons.step_processors import process_steps
 from commons.constants import STAGES_CONFIG_PARAM, INIT_PARAMS_CONFIG_PARAM, \
     OUTPUT_FILE_CONFIG_PARAM, DEPENDS_ON_CONFIG_PARAM, \
-    STAGE_PASSED_REPORT_PARAM, BUNDLE_NAME, UPDATED_BUNDLE_NAME, CLEAN_COMMAND
+    STAGE_PASSED_REPORT_PARAM, BUNDLE_NAME, CLEAN_COMMAND
 from commons.utils import save_json, full_path, split_deploy_bucket_path
 from commons.connections import delete_s3_folder
 
@@ -50,7 +50,6 @@ def force_clean(only_bundle=False):
     config = ConfigHolder(CONF_PATH)
     deploy_bucket, path = split_deploy_bucket_path(config.deploy_target_bucket)
     delete_s3_folder(deploy_bucket, os.path.join(*path, BUNDLE_NAME))
-    delete_s3_folder(deploy_bucket, os.path.join(*path, UPDATED_BUNDLE_NAME))
 
 
 def main(verbose: bool, config: str):

--- a/tests/smoke/sdct-at-ddis-aurora/.gitignore
+++ b/tests/smoke/sdct-at-ddis-aurora/.gitignore
@@ -1,0 +1,3 @@
+.syndicate
+logs/
+.syndicate-config-*/

--- a/tests/smoke/sdct-at-ddis-aurora/.syndicate-config/syndicate.yml
+++ b/tests/smoke/sdct-at-ddis-aurora/.syndicate-config/syndicate.yml
@@ -1,0 +1,13 @@
+aws_access_key_id: 
+aws_secret_access_key: 
+aws_session_token: 
+account_id:
+deploy_target_bucket: 
+extended_prefix_mode: true
+iam_permissions_boundary:
+project_path: FULL_PATH\aws-syndicate\tests\smoke\sdct-at-ddis-aurora
+region: eu-central-1
+resources_prefix: ddis-aurora-
+resources_suffix: -test
+tags:
+  project-level-tag: set-from-project

--- a/tests/smoke/sdct-at-ddis-aurora/.syndicate-config/syndicate_aliases.yml
+++ b/tests/smoke/sdct-at-ddis-aurora/.syndicate-config/syndicate_aliases.yml
@@ -1,0 +1,4 @@
+account_id: ACCOUNT_ID
+lambdas_alias_name: learn
+region: eu-central-1
+logs_expiration: 7

--- a/tests/smoke/sdct-at-ddis-aurora/CHANGELOG.md
+++ b/tests/smoke/sdct-at-ddis-aurora/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - yyyy-MM-dd
+### Added
+    -  Added items
+
+### Changed
+    -  Changed items 
+
+### Removed
+    -  Removed items 

--- a/tests/smoke/sdct-at-ddis-aurora/README.md
+++ b/tests/smoke/sdct-at-ddis-aurora/README.md
@@ -1,0 +1,35 @@
+# sdct-at-ddis-aurora
+The project aims to be used to test aws-syndicate secondary functionality.
+
+## Project resources
+```json
+{
+  "sdct-at-lambda-basic-execution-policy": {
+    "resource_type": "iam_policy"
+  },
+  "sdct-at-java-lambda-role": {
+    "resource_type": "iam_role"
+  },
+  "sdct-at-java-lambda": {
+    "resource_type": "lambda"
+  },
+  "sdct-at-rds-db-cluster": {
+    "resource_type": "rds_db_cluster"
+  },
+  "sdct-at-rds-db-instance": {
+    "resource_type": "rds_db_instance"
+  }
+}
+```
+
+### Notice
+- All resources are supposed for deployment without dependencies
+- Each resource configured to be tagged with the next tags:
+```json
+{
+  "tests": "smoke",
+  "project": "sdct-auto-test"
+}
+```
+- The AWS region where test resources will be deployed must include a default VPC and default subnet, as these are necessary for the deployment of RDS Aurora instances.
+- Due to the slow deployment and cleaning of RDS resources, tests may take up to 40 minutes.

--- a/tests/smoke/sdct-at-ddis-aurora/deployment_resources.json
+++ b/tests/smoke/sdct-at-ddis-aurora/deployment_resources.json
@@ -1,0 +1,73 @@
+{
+  "sdct-at-lambda-basic-execution-policy": {
+    "policy_content": {
+      "Statement": [
+        {
+          "Action": [
+            "logs:CreateLogGroup",
+            "logs:CreateLogStream",
+            "logs:PutLogEvents",
+            "dynamodb:GetItem",
+            "dynamodb:Query",
+            "dynamodb:PutItem",
+            "dynamodb:Batch*",
+            "dynamodb:DeleteItem",
+            "ssm:PutParameter",
+            "ssm:GetParameter",
+            "kms:Decrypt",
+            "dynamodb:GetRecords",
+            "dynamodb:GetShardIterator",
+            "dynamodb:DescribeStream",
+            "dynamodb:ListStreams",
+            "sts:AssumeRole"
+          ],
+          "Effect": "Allow",
+          "Resource": "*"
+        }
+      ],
+      "Version": "2012-10-17"
+    },
+    "resource_type": "iam_policy",
+    "tags": {
+      "tests": "smoke",
+      "project": "sdct-auto-test",
+      "project-level-tag": "set-from-resource"
+    }
+  },
+  "sdct-at-java-lambda-role": {
+    "predefined_policies": [],
+    "principal_service": "lambda",
+    "custom_policies": [
+      "sdct-at-lambda-basic-execution-policy"
+    ],
+    "resource_type": "iam_role",
+    "tags": {
+      "tests": "smoke",
+      "project": "sdct-auto-test"
+    }
+  },
+  "sdct-at-rds-db-cluster": {
+    "resource_type": "rds_db_cluster",
+    "engine": "aurora-postgresql",
+    "master_username": "postgres",
+    "database_name": "logisticdb",
+    "port": 5432,
+    "manage_master_user_password": true,
+    "vpc_security_group_ids": [],
+    "availability_zones": [],
+    "tags": {
+      "tests": "smoke",
+      "project": "sdct-auto-test"
+    }
+  },
+  "sdct-at-rds-db-instance": {
+    "resource_type": "rds_db_instance",
+    "instance_class": "db.t3.medium",
+    "engine": "aurora-postgresql",
+    "cluster_name": "sdct-at-rds-db-cluster",
+    "tags": {
+      "tests": "smoke",
+      "project": "sdct-auto-test"
+    }
+  }
+}

--- a/tests/smoke/sdct-at-ddis-aurora/jsrc/main/java/com/sdctatddisaurora/SdctAtJavaLambda.java
+++ b/tests/smoke/sdct-at-ddis-aurora/jsrc/main/java/com/sdctatddisaurora/SdctAtJavaLambda.java
@@ -17,6 +17,11 @@ import com.syndicate.deployment.model.environment.ValueTransformer;
 import java.util.HashMap;
 import java.util.Map;
 
+@EnvironmentVariables(value = {
+        @EnvironmentVariable(key = "ENDPOINT", value = "sdct-at-rds-db-cluster", valueTransformer = ValueTransformer.RDS_DB_CLUSTER_NAME_TO_ENDPOINT),
+        @EnvironmentVariable(key = "MASTER_CREDENTIALS_SECRET_NAME", value = "sdct-at-rds-db-cluster", valueTransformer = ValueTransformer.RDS_DB_CLUSTER_NAME_TO_MASTER_USER_SECRET_NAME)
+})
+
 @LambdaHandler(
     lambdaName = "sdct-at-java-lambda",
 	roleName = "sdct-at-java-lambda-role",
@@ -25,15 +30,6 @@ import java.util.Map;
 	logsExpiration = RetentionSetting.SYNDICATE_ALIASES_SPECIFIED
 )
 
-@LambdaLayer(
-        layerName = "sdct-at-java-lambda_layer",
-        libraries = {"sdct-at-java-lambda_layer/open-meteo-sdk-1.0.0.jar"},
-        runtime = DeploymentRuntime.JAVA11,
-        artifactExtension = ArtifactExtension.ZIP
-)
-@RuleEventSource(
-        targetRule = "sdct-at-cw-rule"
-)
 @Tags(value = {
     @Tag(key = "tests", value = "smoke"),
     @Tag(key = "project", value = "sdct-auto-test")})

--- a/tests/smoke/sdct-at-ddis-aurora/pom.xml
+++ b/tests/smoke/sdct-at-ddis-aurora/pom.xml
@@ -4,8 +4,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>sdct-at-ddis-group</groupId>
-    <artifactId>sdct-at-ddis</artifactId>
+    <groupId>sdct-at-ddis-aurora-group</groupId>
+    <artifactId>sdct-at-ddis-aurora</artifactId>
     <version>1.0.0</version>
 
     <properties>

--- a/tests/smoke/sdct-at-ddis/.syndicate-config/syndicate_aliases.yml
+++ b/tests/smoke/sdct-at-ddis/.syndicate-config/syndicate_aliases.yml
@@ -4,3 +4,4 @@ region: eu-central-1
 booking_userpool: sdct-at-cup
 reservations_table: sdct-at-reservation
 tables_table: sdct-at-table
+logs_expiration: 7

--- a/tests/smoke/sdct-at-ddis/deployment_resources.json
+++ b/tests/smoke/sdct-at-ddis/deployment_resources.json
@@ -173,6 +173,7 @@
     "resource_type": "dynamodb_table",
     "hash_key_name": "id",
     "hash_key_type": "N",
+    "billing-mode": "PAY_PER_REQUEST",
     "read_capacity": 1,
     "write_capacity": 1,
     "global_indexes": [
@@ -192,6 +193,7 @@
     "resource_type": "dynamodb_table",
     "hash_key_name": "id",
     "hash_key_type": "N",
+    "billing-mode": "PROVISIONED",
     "read_capacity": 2,
     "write_capacity": 1,
     "autoscaling": [],

--- a/tests/smoke/sdct-at-ddis/deployment_resources.json
+++ b/tests/smoke/sdct-at-ddis/deployment_resources.json
@@ -246,29 +246,5 @@
       "tests": "smoke",
       "project": "sdct-auto-test"
     }
-  },
-  "sdct-at-rds-db-cluster": {
-    "resource_type": "rds_db_cluster",
-    "engine": "aurora-postgresql",
-    "master_username": "postgres",
-    "database_name": "logisticdb",
-    "port": 5432,
-    "manage_master_user_password": true,
-    "vpc_security_group_ids": [],
-    "availability_zones": [],
-    "tags": {
-      "tests": "smoke",
-      "project": "sdct-auto-test"
-    }
-  },
-  "sdct-at-rds-db-instance": {
-    "resource_type": "rds_db_instance",
-    "instance_class": "db.t3.medium",
-    "engine": "aurora-postgresql",
-    "cluster_name": "sdct-at-rds-db-cluster",
-    "tags": {
-      "tests": "smoke",
-      "project": "sdct-auto-test"
-    }
   }
 }

--- a/tests/smoke/sdct-at-ddis/deployment_resources_updated.json
+++ b/tests/smoke/sdct-at-ddis/deployment_resources_updated.json
@@ -176,6 +176,7 @@
     "resource_type": "dynamodb_table",
     "hash_key_name": "id",
     "hash_key_type": "N",
+    "billing-mode": "PAY_PER_REQUEST",
     "read_capacity": 1,
     "write_capacity": 1,
     "global_indexes": [
@@ -195,6 +196,7 @@
     "resource_type": "dynamodb_table",
     "hash_key_name": "id",
     "hash_key_type": "N",
+    "billing-mode": "PROVISIONED",
     "read_capacity": 2,
     "write_capacity": 1,
     "autoscaling": [],

--- a/tests/smoke/sdct-at-ddis/deployment_resources_updated.json
+++ b/tests/smoke/sdct-at-ddis/deployment_resources_updated.json
@@ -249,29 +249,5 @@
       "tests": "smoke",
       "project": "sdct-auto-test"
     }
-  },
-  "sdct-at-rds-db-cluster": {
-    "resource_type": "rds_db_cluster",
-    "engine": "aurora-postgresql",
-    "master_username": "postgres",
-    "database_name": "logisticdb",
-    "port": 5432,
-    "manage_master_user_password": true,
-    "vpc_security_group_ids": [],
-    "availability_zones": [],
-    "tags": {
-      "tests": "smoke",
-      "project": "sdct-auto-test"
-    }
-  },
-  "sdct-at-rds-db-instance": {
-    "resource_type": "rds_db_instance",
-    "instance_class": "db.t3.medium",
-    "engine": "aurora-postgresql",
-    "cluster_name": "sdct-at-rds-db-cluster",
-    "tags": {
-      "tests": "smoke",
-      "project": "sdct-auto-test"
-    }
   }
 }

--- a/tests/smoke/sdct-at-ddis/src/lambdas/layers/sdct-at-python-lambda_layer/requirements.txt
+++ b/tests/smoke/sdct-at-ddis/src/lambdas/layers/sdct-at-python-lambda_layer/requirements.txt
@@ -1,2 +1,1 @@
-boto3==1.26.80
-botocore==1.29.80
+requests

--- a/tests/smoke/sdct-at-least-used-resources/.syndicate-config/syndicate_aliases.yml
+++ b/tests/smoke/sdct-at-least-used-resources/.syndicate-config/syndicate_aliases.yml
@@ -3,3 +3,4 @@ region: eu-central-1
 lambdas_alias_name: learn
 sg_id: existing_default_security_group_id
 subnet_id: existing_default_vpc_subnet_id
+logs_expiration: 7


### PR DESCRIPTION
- Fixed an issue that leads to the permanent warning in case of filtering resources by name during the `deploy`, `update`, and `clean` commands
- Added information message with resource names to be processed to the user console log in case of filtering resources during the `deploy`, `update`, and `clean` commands
- Added abortion of the `deploy`, `update`, and `clean` commands in case no resources to process after filtering