### PR TITLE
Fix incorrect import in `commons/__init__.py`

### DIFF
--- a/syndicate/core/generators/contents.py
+++ b/syndicate/core/generators/contents.py
@@ -382,7 +382,7 @@ class AbstractLambda:
                                   content='Internal server error')
 """
 
-INIT_CONTENT = """from commons.exception import ApplicationException
+INIT_CONTENT = """from commons.exceptions import ApplicationException
 
 RESPONSE_BAD_REQUEST_CODE = 400
 RESPONSE_UNAUTHORIZED = 401


### PR DESCRIPTION
# Fix incorrect import in `commons/__init__.py`

## Description
In the `commons` module, the file is named **`exceptions.py`**, but the import statement in `__init__.py` referred to **`commons.exception`** (missing "s").  
This caused an `ImportError` when trying to use `ApplicationException`.
<img width="1593" height="863" alt="image" src="https://github.com/user-attachments/assets/8ca21b60-da96-43a4-af88-10e0978e19b3" />


This PR updates the import to:
```python
from commons.exceptions import ApplicationException
```

**Test plan (required)**

I tested it after installing it locally. The result is shown in the screenshot below.

<img width="1855" height="1300" alt="image" src="https://github.com/user-attachments/assets/4bed7726-67fb-4fed-81e2-9e1e244edc70" />
