### PR TITLE
Fixed an issue when syndicate build reset indent to 0 in appsync_confing.json file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [1.18.4] - 2025-10-06
 - Fixed an issue when failed 'update' overrides latest_deploy in state file.
+- Fixed an issue when `syndicate build` reset indent to 0 in `appsync_config.json` file.
 
 # [1.18.3] - 2025-09-11
 - Fixed issue in the lambda function with the runtime Python template

--- a/syndicate/core/build/runtime/appsync.py
+++ b/syndicate/core/build/runtime/appsync.py
@@ -80,7 +80,7 @@ def assemble_appsync(project_path, bundles_dir, **kwargs):
             appsync_conf['deployment_package'] = artifact_name
 
             with open(conf_file_path, 'w') as file:
-                json.dump(appsync_conf, file)
+                json.dump(appsync_conf, file, indent=4)
 
             resolvers = appsync_conf.get('resolvers', [])
             functions = appsync_conf.get('functions', [])


### PR DESCRIPTION
Fixed an issue when syndicate build reset indent to 0 in appsync_confing.json file