### PR TITLE
Fixed an issue with resolving prefix and suffix of resource names within ARN.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # [1.19.2] - 2026-01-27
 - Fixed an issue with `syndicate generate project` command, when the `SDCT_CONF` is missing.
 - Fixed an issue related to deploying Lambda configured with a specific subnet and role containing multiple IAM policies.
+- Fixed an issue with resolving prefixes and suffixes of resource names within ARN.
 
 # [1.19.1] - 2026-01-12
 - Updated lambda function permissions deployment to comply with AWS requirements for `function URL`


### PR DESCRIPTION
Added a processing scenario where the resource name is placed inside the ARN.

**Test plan**

I built and deployed a test project with resources as in the example. 
The prefix and suffix are processed correctly.
<img width="1486" height="906" alt="image" src="https://github.com/user-attachments/assets/8c9ef2b0-3117-45ee-b276-21abed121f4e" />


**Closing issues**

`closes [EPMCEOOS-11256](https://jiraeu.epam.com/browse/EPMCEOOS-11256)
