### PR TITLE
Fixed Python Lambda layer packaging when `requirements.txt` is empty …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deprecated test framework `nose` and replaced it with `nose2` for Python runtime
 - Added `--suite` and `--test-folder-name` options to `syndicate build` command to specify the test suite and test folder name for the build process
 - Fixed an issue where `binary_media_types` were not applied when updating an `api_gateway` resource
+- Fixed Python Lambda layer packaging when `requirements.txt` is empty or absent
 
 # [1.21.2] - 2026-07-01
 - Fixed Python lambda function dependencies resolving issue when it conflicted with aws-syndicate dependencies

--- a/syndicate/core/build/runtime/python.py
+++ b/syndicate/core/build/runtime/python.py
@@ -240,14 +240,22 @@ def build_python_lambda_layer(
         zip_dir(str(tmp_artifact_path),
                 str(Path(artifact_path, package_name)))
 
-    if ((Path(cache_dir_path, package_name).exists() or
-        Path(artifact_path, package_name).exists()) and
-            current_req_hash != EMPTY_FILE_HASH):
+    layer_package_path = Path(artifact_path, package_name)
+    dependency_package_path = Path(cache_dir_path, package_name)
+    has_layer_code = layer_package_path.exists()
+    has_dependencies = (
+        current_req_hash != EMPTY_FILE_HASH and
+        dependency_package_path.exists()
+    )
+
+    if has_layer_code or has_dependencies:
         _LOG.info(f"Merging lambda layer code with 3-rd party dependencies")
-        merge_zip_files(str(Path(artifact_path, package_name)),
-                        str(Path(cache_dir_path, package_name)),
-                        str(Path(bundle_dir, package_name)),
-                        output_subfolder=PYTHON_LAMBDA_LAYER_PATH)
+        merge_zip_files(
+            str(layer_package_path),
+            str(dependency_package_path) if has_dependencies else '',
+            str(Path(bundle_dir, package_name)),
+            output_subfolder=PYTHON_LAMBDA_LAYER_PATH,
+        )
     else:
         raise ArtifactAssemblingError(
             f"Layer package cannot be empty. "


### PR DESCRIPTION
Python Lambda layers with empty or absent requirements.txt should build successfully when they contain local dependencies. Dependency-based layers must continue working, while genuinely empty layers should still be rejected.